### PR TITLE
Decorators for validation

### DIFF
--- a/src/handler_params.py
+++ b/src/handler_params.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright 2017 - Edoardo Morassutto <edoardo.morassutto@gmail.com>
+import inspect
+
+
+class HandlerParams:
+
+    HANDLER_PARAMS_ATTR = "handler_params"
+
+    @staticmethod
+    def initialize_handler_params(handle, handler):
+        if not hasattr(handle, HandlerParams.HANDLER_PARAMS_ATTR):
+            if hasattr(handler, HandlerParams.HANDLER_PARAMS_ATTR):
+                setattr(handle, HandlerParams.HANDLER_PARAMS_ATTR, getattr(handler, HandlerParams.HANDLER_PARAMS_ATTR))
+            else:
+                setattr(handle, HandlerParams.HANDLER_PARAMS_ATTR, HandlerParams.get_handler_params(handler))
+        return handle
+
+    @staticmethod
+    def get_handler_params(handle):
+        if hasattr(handle, HandlerParams.HANDLER_PARAMS_ATTR):
+            return getattr(handle, HandlerParams.HANDLER_PARAMS_ATTR)
+        params = {}
+        sign = inspect.signature(handle).parameters
+
+        for name in sign:
+            if name == "self": continue
+            type = sign[name].annotation if sign[name].annotation is not inspect._empty else None
+            req = sign[name].default == inspect._empty
+
+            params[name] = {
+                "type": type,
+                "required": req
+            }
+        return params
+
+    @staticmethod
+    def add_handler_param(handle, param, type, required=True):
+        params = getattr(handle, HandlerParams.HANDLER_PARAMS_ATTR)
+        params[param] = {
+            "type": type,
+            "required": required
+        }
+        return handle
+
+    @staticmethod
+    def remove_handler_param(handle, name):
+        params = getattr(handle, HandlerParams.HANDLER_PARAMS_ATTR)
+        if name in params:
+            del params[name]

--- a/src/handlers/admin_handler.py
+++ b/src/handlers/admin_handler.py
@@ -22,8 +22,8 @@ from werkzeug.exceptions import Forbidden, BadRequest
 
 class AdminHandler(BaseHandler):
 
-    @Validators.admin_only
-    def extract(self, *, filename:str, password:str, **kwargs):
+    @Validators.validate_admin_only
+    def extract(self, filename:str, password:str):
         """
         POST /admin/extract
         """
@@ -43,8 +43,8 @@ class AdminHandler(BaseHandler):
         ContestManager.start()
         return {}
 
-    @Validators.admin_only
-    def log(self, *, start_date:str, end_date:str, level:str, category:str=None, **kwargs):
+    @Validators.validate_admin_only
+    def log(self, start_date:str, end_date:str, level:str, category:str=None):
         """
         POST /admin/log
         """
@@ -58,8 +58,8 @@ class AdminHandler(BaseHandler):
             "items": Logger.get_logs(level, category, start_date, end_date)
         })
 
-    @Validators.admin_only
-    def start(self, **kwargs):
+    @Validators.validate_admin_only
+    def start(self):
         """
         POST /admin/start
         """
@@ -73,8 +73,8 @@ class AdminHandler(BaseHandler):
             fields=["start_time"]
         )
 
-    @Validators.admin_only
-    def set_extra_time(self, *, extra_time:int, token:str=None, **kwargs):
+    @Validators.validate_admin_only
+    def set_extra_time(self, extra_time:int, token:str=None):
         """
         POST /admin/set_extra_time
         """
@@ -86,8 +86,8 @@ class AdminHandler(BaseHandler):
             Database.set_extra_time(token, extra_time)
         return {}
 
-    @Validators.admin_only
-    def status(self, **kwargs):
+    @Validators.validate_admin_only
+    def status(self):
         """
         POST /admin/status
         """
@@ -102,8 +102,8 @@ class AdminHandler(BaseHandler):
             "loaded": ContestManager.has_contest
         }, fields=["start_time"])
 
-    @Validators.admin_only
-    def user_list(self, **kwargs):
+    @Validators.validate_admin_only
+    def user_list(self):
         """
         POST /admin/user_list
         """

--- a/src/handlers/admin_handler.py
+++ b/src/handlers/admin_handler.py
@@ -74,16 +74,15 @@ class AdminHandler(BaseHandler):
         )
 
     @Validators.admin_only
-    def set_extra_time(self, extra_time:int, token:str=None):
+    @Validators.validate_id("token", "user", Database.get_user, required=False)
+    def set_extra_time(self, extra_time:int, user):
         """
         POST /admin/set_extra_time
         """
-        if token is None:
+        if user is None:
             Database.set_meta("extra_time", extra_time)
-        elif Database.get_user(token) is None:
-            BaseHandler.raise_exc(Forbidden, "FORBIDDEN", "No such user")
         else:
-            Database.set_extra_time(token, extra_time)
+            Database.set_extra_time(user["token"], extra_time)
         return {}
 
     @Validators.admin_only

--- a/src/handlers/admin_handler.py
+++ b/src/handlers/admin_handler.py
@@ -22,7 +22,7 @@ from werkzeug.exceptions import Forbidden, BadRequest
 class AdminHandler(BaseHandler):
 
     @BaseHandler.admin_only
-    def extract(self, *, admin_token:str, filename:str, password:str, _ip):
+    def extract(self, *, filename:str, password:str, **kwargs):
         """
         POST /admin/extract
         """
@@ -43,7 +43,7 @@ class AdminHandler(BaseHandler):
         return {}
 
     @BaseHandler.admin_only
-    def log(self, *, start_date:str, end_date:str, level:str, admin_token:str, category:str=None, _ip):
+    def log(self, *, start_date:str, end_date:str, level:str, category:str=None, **kwargs):
         """
         POST /admin/log
         """
@@ -58,7 +58,7 @@ class AdminHandler(BaseHandler):
         })
 
     @BaseHandler.admin_only
-    def start(self, *, admin_token:str, _ip):
+    def start(self, **kwargs):
         """
         POST /admin/start
         """
@@ -73,7 +73,7 @@ class AdminHandler(BaseHandler):
         )
 
     @BaseHandler.admin_only
-    def set_extra_time(self, *, admin_token:str, extra_time:int, _ip, token:str=None):
+    def set_extra_time(self, *, extra_time:int, token:str=None, **kwargs):
         """
         POST /admin/set_extra_time
         """
@@ -84,7 +84,7 @@ class AdminHandler(BaseHandler):
         return {}
 
     @BaseHandler.admin_only
-    def status(self, *, admin_token:str, _ip):
+    def status(self, **kwargs):
         """
         POST /admin/status
         """
@@ -100,7 +100,7 @@ class AdminHandler(BaseHandler):
         }, fields=["start_time"])
 
     @BaseHandler.admin_only
-    def user_list(self, *, admin_token:str, _ip):
+    def user_list(self, **kwargs):
         """
         POST /admin/user_list
         """

--- a/src/handlers/admin_handler.py
+++ b/src/handlers/admin_handler.py
@@ -22,7 +22,7 @@ from werkzeug.exceptions import Forbidden, BadRequest
 
 class AdminHandler(BaseHandler):
 
-    @Validators.validate_admin_only
+    @Validators.admin_only
     def extract(self, filename:str, password:str):
         """
         POST /admin/extract
@@ -43,7 +43,7 @@ class AdminHandler(BaseHandler):
         ContestManager.start()
         return {}
 
-    @Validators.validate_admin_only
+    @Validators.admin_only
     def log(self, start_date:str, end_date:str, level:str, category:str=None):
         """
         POST /admin/log
@@ -58,7 +58,7 @@ class AdminHandler(BaseHandler):
             "items": Logger.get_logs(level, category, start_date, end_date)
         })
 
-    @Validators.validate_admin_only
+    @Validators.admin_only
     def start(self):
         """
         POST /admin/start
@@ -73,7 +73,7 @@ class AdminHandler(BaseHandler):
             fields=["start_time"]
         )
 
-    @Validators.validate_admin_only
+    @Validators.admin_only
     def set_extra_time(self, extra_time:int, token:str=None):
         """
         POST /admin/set_extra_time
@@ -86,7 +86,7 @@ class AdminHandler(BaseHandler):
             Database.set_extra_time(token, extra_time)
         return {}
 
-    @Validators.validate_admin_only
+    @Validators.admin_only
     def status(self):
         """
         POST /admin/status
@@ -102,7 +102,7 @@ class AdminHandler(BaseHandler):
             "loaded": ContestManager.has_contest
         }, fields=["start_time"])
 
-    @Validators.validate_admin_only
+    @Validators.admin_only
     def user_list(self):
         """
         POST /admin/user_list

--- a/src/handlers/base_handler.py
+++ b/src/handlers/base_handler.py
@@ -220,8 +220,6 @@ class BaseHandler:
         sign = inspect.signature(handle).parameters
 
         for name in sign:
-            if name == "self":
-                continue
             type = sign[name].annotation if sign[name].annotation is not inspect._empty else None
             req = sign[name].default == inspect._empty
 

--- a/src/handlers/base_handler.py
+++ b/src/handlers/base_handler.py
@@ -242,7 +242,7 @@ class BaseHandler:
             if submission: return submission["token"]
         else:
             print("I cannot guess the token from these kwargs", kwargs)
-            traceback.print_tb()
+            traceback.print_stack()
         return None
 
     @staticmethod

--- a/src/handlers/base_handler.py
+++ b/src/handlers/base_handler.py
@@ -209,9 +209,12 @@ class BaseHandler:
 
     # TODO move this code somewhere else
     @staticmethod
-    def initialize_request_params(handle):
+    def initialize_request_params(handle, handler):
         if not hasattr(handle, "request_params"):
-            handle.request_params = BaseHandler.get_request_params(handle)
+            if hasattr(handler, "request_params"):
+                handle.request_params = handler.request_params
+            else:
+                handle.request_params = BaseHandler.get_request_params(handler)
         return handle
 
     @staticmethod
@@ -220,6 +223,7 @@ class BaseHandler:
         sign = inspect.signature(handle).parameters
 
         for name in sign:
+            if name == "self": continue
             type = sign[name].annotation if sign[name].annotation is not inspect._empty else None
             req = sign[name].default == inspect._empty
 

--- a/src/handlers/base_handler.py
+++ b/src/handlers/base_handler.py
@@ -129,20 +129,24 @@ class BaseHandler:
         general_attrs = {
             '_request': request,
             '_route_args': route_args,
-            '_file_content': BaseHandler._get_file_content(request),
-            '_file_name': BaseHandler._get_file_name(request),
+            '_file': {
+                "content": BaseHandler._get_file_content(request),
+                "name": BaseHandler._get_file_name(request)
+            },
             '_ip': BaseHandler.get_ip(request)
         }
 
         missing_parameters = []
 
         for name, data in params.items():
-            if name in route_args:
+            if name in route_args and name[0] != "_":
                 kwargs[name] = route_args[name]
-            elif name in request.form:
+            elif name in request.form and name[0] != "_":
                 kwargs[name] = request.form[name]
             elif name in general_attrs:
                 kwargs[name] = general_attrs[name]
+            elif name == "file" and general_attrs["_file"]["name"] is not None:
+                kwargs[name] = general_attrs["_file"]
             elif data["required"]:
                 missing_parameters.append(name)
 
@@ -166,7 +170,7 @@ class BaseHandler:
                 method.__name__,
                 ", with parameters " + ", ".join(
                         "=".join((kv[0], str(kv[1]))) for kv in kwargs.items()
-                            if not kv[0].startswith("_")
+                            if not kv[0].startswith("_") and not kv[0] == "file"
                 ) if len(kwargs) > 0 else ""
             )
         )

--- a/src/handlers/contest_handler.py
+++ b/src/handlers/contest_handler.py
@@ -33,15 +33,15 @@ class ContestHandler(BaseHandler):
         if task_score["score"] < score:
             Database.set_user_score(token, task, score, autocommit=False)
 
-    @Validators.during_contest
-    @Validators.register_ip
-    @Validators.valid_token
-    @Validators.valid_task
-    def generate_input(self, *, token, **kwargs):
+    @Validators.validate_during_contest
+    @Validators.register_user_ip
+    @Validators.validate_token
+    @Validators.validate_task
+    def generate_input(self, task, user):
         """
         POST /generate_input
         """
-        task = kwargs["task"]
+        token = user["token"]
         if Database.get_user_task(token, task["name"])["current_attempt"] is not None:
             self.raise_exc(Forbidden, "FORBIDDEN", "You already have a ready input!")
 
@@ -59,16 +59,14 @@ class ContestHandler(BaseHandler):
             raise
         return BaseHandler.format_dates(Database.get_input(id=id))
 
-    @Validators.during_contest
-    @Validators.register_ip
-    @Validators.valid_output_id
-    @Validators.valid_source_id
-    def submit(self, **kwargs):
+    @Validators.validate_during_contest
+    @Validators.register_user_ip
+    @Validators.validate_output_id
+    @Validators.validate_source_id
+    def submit(self, output, source):
         """
         POST /submit
         """
-        output = kwargs["output"]
-        source = kwargs["source"]
         input = Database.get_input(output["input"])
         if input is None:
             Logger.warning("DB_CONSISTENCY_ERROR", "Input %s not found in the db" % output["input"])

--- a/src/handlers/contest_handler.py
+++ b/src/handlers/contest_handler.py
@@ -33,7 +33,7 @@ class ContestHandler(BaseHandler):
         if task_score["score"] < score:
             Database.set_user_score(token, task, score, autocommit=False)
 
-    @Validators.validate_during_contest
+    @Validators.during_contest
     @Validators.register_user_ip
     @Validators.validate_token
     @Validators.validate_task
@@ -59,7 +59,7 @@ class ContestHandler(BaseHandler):
             raise
         return BaseHandler.format_dates(Database.get_input(id=id))
 
-    @Validators.validate_during_contest
+    @Validators.during_contest
     @Validators.register_user_ip
     @Validators.validate_output_id
     @Validators.validate_source_id

--- a/src/handlers/contest_handler.py
+++ b/src/handlers/contest_handler.py
@@ -32,7 +32,8 @@ class ContestHandler(BaseHandler):
         if task_score["score"] < score:
             Database.set_user_score(token, task, score, autocommit=False)
 
-    def generate_input(self, token:str, task:str, _ip):
+    @BaseHandler.during_contest
+    def generate_input(self, *, token:str, task:str, _ip):
         """
         POST /generate_input
         """
@@ -59,15 +60,16 @@ class ContestHandler(BaseHandler):
             raise
         return BaseHandler.format_dates(Database.get_input(id=id))
 
-    def submit(self, output:str, source:str, _ip):
+    @BaseHandler.during_contest
+    def submit(self, *, output_id:str, source_id:str, _ip):
         """
         POST /submit
         """
 
-        output = Database.get_output(output)
+        output = Database.get_output(output_id)
         if output is None:
             self.raise_exc(Forbidden, "FORBIDDEN", "No such output file")
-        source = Database.get_source(source)
+        source = Database.get_source(source_id)
         if source is None:
             self.raise_exc(Forbidden, "FORBIDDEN", "No such source file")
 

--- a/src/handlers/contest_handler.py
+++ b/src/handlers/contest_handler.py
@@ -8,6 +8,7 @@
 # Copyright 2017 - Massimo Cairo <cairomassimo@gmail.com>
 import json
 
+from ..validators import Validators
 from ..logger import Logger
 from .info_handler import InfoHandler
 from .base_handler import BaseHandler
@@ -32,47 +33,42 @@ class ContestHandler(BaseHandler):
         if task_score["score"] < score:
             Database.set_user_score(token, task, score, autocommit=False)
 
-    @BaseHandler.during_contest
-    def generate_input(self, *, token:str, task:str, _ip, **kwargs):
+    @Validators.during_contest
+    @Validators.register_ip
+    @Validators.valid_token
+    @Validators.valid_task
+    def generate_input(self, *, token, **kwargs):
         """
         POST /generate_input
         """
-        if Database.get_user(token) is None:
-            self.raise_exc(Forbidden, "FORBIDDEN", "No such user")
-        if Database.get_task(task) is None:
-            self.raise_exc(Forbidden, "FORBIDDEN", "No such task")
-        if Database.get_user_task(token, task)["current_attempt"] is not None:
+        task = kwargs["task"]
+        if Database.get_user_task(token, task["name"])["current_attempt"] is not None:
             self.raise_exc(Forbidden, "FORBIDDEN", "You already have a ready input!")
 
-        Database.register_ip(token, _ip)
-
-        attempt = Database.get_next_attempt(token, task)
-        id, path = ContestManager.get_input(task, attempt)
+        attempt = Database.get_next_attempt(token, task["name"])
+        id, path = ContestManager.get_input(task["name"], attempt)
         size = StorageManager.get_file_size(path)
 
         Database.begin()
         try:
-            Database.add_input(id, token, task, attempt, path, size, autocommit=False)
-            Database.set_user_attempt(token, task, attempt, autocommit=False)
+            Database.add_input(id, token, task["name"], attempt, path, size, autocommit=False)
+            Database.set_user_attempt(token, task["name"], attempt, autocommit=False)
             Database.commit()
         except:
             Database.rollback()
             raise
         return BaseHandler.format_dates(Database.get_input(id=id))
 
-    @BaseHandler.during_contest
-    def submit(self, *, output_id:str, source_id:str, _ip, **kwargs):
+    @Validators.during_contest
+    @Validators.register_ip
+    @Validators.valid_output_id
+    @Validators.valid_source_id
+    def submit(self, **kwargs):
         """
         POST /submit
         """
-
-        output = Database.get_output(output_id)
-        if output is None:
-            self.raise_exc(Forbidden, "FORBIDDEN", "No such output file")
-        source = Database.get_source(source_id)
-        if source is None:
-            self.raise_exc(Forbidden, "FORBIDDEN", "No such source file")
-
+        output = kwargs["output"]
+        source = kwargs["source"]
         input = Database.get_input(output["input"])
         if input is None:
             Logger.warning("DB_CONSISTENCY_ERROR", "Input %s not found in the db" % output["input"])
@@ -80,9 +76,6 @@ class ContestHandler(BaseHandler):
         if output["input"] != source["input"]:
             Logger.warning("POSSIBLE_CHEAT", "Trying to submit wrong pair source-output")
             self.raise_exc(Forbidden, "WRONG_OUTPUT_SOURCE", "The provided pair of source-output is invalid")
-
-        token = input["token"]
-        Database.register_ip(token, _ip)
 
         score = ContestHandler.compute_score(input["task"], output["result"])
         Database.begin()

--- a/src/handlers/contest_handler.py
+++ b/src/handlers/contest_handler.py
@@ -33,7 +33,7 @@ class ContestHandler(BaseHandler):
             Database.set_user_score(token, task, score, autocommit=False)
 
     @BaseHandler.during_contest
-    def generate_input(self, *, token:str, task:str, _ip):
+    def generate_input(self, *, token:str, task:str, _ip, **kwargs):
         """
         POST /generate_input
         """
@@ -61,7 +61,7 @@ class ContestHandler(BaseHandler):
         return BaseHandler.format_dates(Database.get_input(id=id))
 
     @BaseHandler.during_contest
-    def submit(self, *, output_id:str, source_id:str, _ip):
+    def submit(self, *, output_id:str, source_id:str, _ip, **kwargs):
         """
         POST /submit
         """

--- a/src/handlers/info_handler.py
+++ b/src/handlers/info_handler.py
@@ -17,7 +17,7 @@ from werkzeug.exceptions import Forbidden
 
 class InfoHandler(BaseHandler):
 
-    def get_contest(self):
+    def get_contest(self, **kwargs):
         """
         GET /contest
         """
@@ -36,7 +36,7 @@ class InfoHandler(BaseHandler):
         }
 
     @BaseHandler.during_contest
-    def get_input(self, *, input_id:str, _ip):
+    def get_input(self, *, input_id:str, _ip, **kwargs):
         """
         GET /input/<id>
         """
@@ -50,7 +50,7 @@ class InfoHandler(BaseHandler):
         return BaseHandler.format_dates(input_file)
 
     @BaseHandler.during_contest
-    def get_output(self, *, output_id:str, _ip):
+    def get_output(self, *, output_id:str, _ip, **kwargs):
         """
         GET /output/<id>
         """
@@ -65,7 +65,7 @@ class InfoHandler(BaseHandler):
         return InfoHandler.patch_output(output_file)
 
     @BaseHandler.during_contest
-    def get_source(self, *, source_id:str, _ip):
+    def get_source(self, *, source_id:str, _ip, **kwargs):
         """
         GET /source/<id>
         """
@@ -80,7 +80,7 @@ class InfoHandler(BaseHandler):
         return BaseHandler.format_dates(source_file)
 
     @BaseHandler.during_contest
-    def get_submission(self, *, submission_id:str, _ip):
+    def get_submission(self, *, submission_id:str, _ip, **kwargs):
         """
         GET /submission/<id>
         """
@@ -94,7 +94,7 @@ class InfoHandler(BaseHandler):
         return InfoHandler.patch_submission(submission)
 
     @BaseHandler.during_contest
-    def get_user(self, *, token:str, _ip):
+    def get_user(self, *, token:str, _ip, **kwargs):
         """
         GET /user/<token>
         """
@@ -131,7 +131,7 @@ class InfoHandler(BaseHandler):
         return BaseHandler.format_dates(user, fields=["date"])
 
     @BaseHandler.during_contest
-    def get_submissions(self, *, token:str, task:str, _ip):
+    def get_submissions(self, *, token:str, task:str, _ip, **kwargs):
         """
         GET /user/<token>/submissions/<task>
         """

--- a/src/handlers/info_handler.py
+++ b/src/handlers/info_handler.py
@@ -17,7 +17,7 @@ from datetime import datetime
 
 class InfoHandler(BaseHandler):
 
-    def get_contest(self, **kwargs):
+    def get_contest(self):
         """
         GET /contest
         """
@@ -35,54 +35,49 @@ class InfoHandler(BaseHandler):
             "tasks": Database.get_tasks()
         }
 
-    @Validators.during_contest
-    @Validators.register_ip
-    @Validators.valid_input_id
-    def get_input(self, **kwargs):
+    @Validators.validate_during_contest
+    @Validators.register_user_ip
+    @Validators.validate_input_id
+    def get_input(self, input):
         """
         GET /input/<input_id>
         """
-        input_file = kwargs["input"]
-        return BaseHandler.format_dates(input_file)
+        return BaseHandler.format_dates(input)
 
-    @Validators.during_contest
-    @Validators.register_ip
-    @Validators.valid_output_id
-    def get_output(self, **kwargs):
+    @Validators.validate_during_contest
+    @Validators.register_user_ip
+    @Validators.validate_output_id
+    def get_output(self, output):
         """
         GET /output/<output_id>
         """
-        output_file = kwargs["output"]
-        return InfoHandler.patch_output(output_file)
+        return InfoHandler.patch_output(output)
 
-    @Validators.during_contest
-    @Validators.register_ip
-    @Validators.valid_source_id
-    def get_source(self, **kwargs):
+    @Validators.validate_during_contest
+    @Validators.register_user_ip
+    @Validators.validate_source_id
+    def get_source(self, source):
         """
         GET /source/<source_id>
         """
-        source_file = kwargs["source"]
-        return BaseHandler.format_dates(source_file)
+        return BaseHandler.format_dates(source)
 
-    @Validators.during_contest
-    @Validators.register_ip
-    @Validators.valid_submission_id
-    def get_submission(self, **kwargs):
+    @Validators.validate_during_contest
+    @Validators.register_user_ip
+    @Validators.validate_submission_id
+    def get_submission(self, submission):
         """
         GET /submission/<submission_id>
         """
-        submission = kwargs["submission"]
         return InfoHandler.patch_submission(submission)
 
-    @Validators.during_contest
-    @Validators.register_ip
-    @Validators.valid_token
-    def get_user(self, **kwargs):
+    @Validators.validate_during_contest
+    @Validators.register_user_ip
+    @Validators.validate_token
+    def get_user(self, user):
         """
         GET /user/<token>
         """
-        user = kwargs["user"]
         token = user["token"]
 
         user["remaining_time"] = InfoHandler.get_remaining_time(user["extra_time"])
@@ -110,18 +105,16 @@ class InfoHandler(BaseHandler):
 
         return BaseHandler.format_dates(user, fields=["date"])
 
-    @Validators.during_contest
-    @Validators.register_ip
-    @Validators.valid_token
-    @Validators.valid_task
-    def get_submissions(self, **kwargs):
+    @Validators.validate_during_contest
+    @Validators.register_user_ip
+    @Validators.validate_token
+    @Validators.validate_task
+    def get_submissions(self, user, task):
         """
         GET /user/<token>/submissions/<task>
         """
-        task = kwargs["task"]
-
         submissions = []
-        for sub in Database.get_submissions(kwargs["token"], task["name"]):
+        for sub in Database.get_submissions(user["token"], task["name"]):
             submissions.append(InfoHandler.patch_submission(sub))
         return { "items": submissions }
 

--- a/src/handlers/info_handler.py
+++ b/src/handlers/info_handler.py
@@ -35,7 +35,7 @@ class InfoHandler(BaseHandler):
             "tasks": Database.get_tasks()
         }
 
-    @Validators.validate_during_contest
+    @Validators.during_contest
     @Validators.register_user_ip
     @Validators.validate_input_id
     def get_input(self, input):
@@ -44,7 +44,7 @@ class InfoHandler(BaseHandler):
         """
         return BaseHandler.format_dates(input)
 
-    @Validators.validate_during_contest
+    @Validators.during_contest
     @Validators.register_user_ip
     @Validators.validate_output_id
     def get_output(self, output):
@@ -53,7 +53,7 @@ class InfoHandler(BaseHandler):
         """
         return InfoHandler.patch_output(output)
 
-    @Validators.validate_during_contest
+    @Validators.during_contest
     @Validators.register_user_ip
     @Validators.validate_source_id
     def get_source(self, source):
@@ -62,7 +62,7 @@ class InfoHandler(BaseHandler):
         """
         return BaseHandler.format_dates(source)
 
-    @Validators.validate_during_contest
+    @Validators.during_contest
     @Validators.register_user_ip
     @Validators.validate_submission_id
     def get_submission(self, submission):
@@ -71,7 +71,7 @@ class InfoHandler(BaseHandler):
         """
         return InfoHandler.patch_submission(submission)
 
-    @Validators.validate_during_contest
+    @Validators.during_contest
     @Validators.register_user_ip
     @Validators.validate_token
     def get_user(self, user):
@@ -105,7 +105,7 @@ class InfoHandler(BaseHandler):
 
         return BaseHandler.format_dates(user, fields=["date"])
 
-    @Validators.validate_during_contest
+    @Validators.during_contest
     @Validators.register_user_ip
     @Validators.validate_token
     @Validators.validate_task

--- a/src/handlers/info_handler.py
+++ b/src/handlers/info_handler.py
@@ -35,11 +35,12 @@ class InfoHandler(BaseHandler):
             "tasks": Database.get_tasks()
         }
 
-    def get_input(self, id:str, _ip):
+    @BaseHandler.during_contest
+    def get_input(self, *, input_id:str, _ip):
         """
         GET /input/<id>
         """
-        input_file = Database.get_input(id=id)
+        input_file = Database.get_input(id=input_id)
         if not input_file:
             self.raise_exc(Forbidden, "FORBIDDEN", "You cannot get the required input")
 
@@ -48,11 +49,12 @@ class InfoHandler(BaseHandler):
 
         return BaseHandler.format_dates(input_file)
 
-    def get_output(self, id:str, _ip):
+    @BaseHandler.during_contest
+    def get_output(self, *, output_id:str, _ip):
         """
         GET /output/<id>
         """
-        output_file = Database.get_output(id=id)
+        output_file = Database.get_output(id=output_id)
         if not output_file:
             self.raise_exc(Forbidden, "FORBIDDEN", "You cannot get the required output")
 
@@ -62,11 +64,12 @@ class InfoHandler(BaseHandler):
 
         return InfoHandler.patch_output(output_file)
 
-    def get_source(self, id:str, _ip):
+    @BaseHandler.during_contest
+    def get_source(self, *, source_id:str, _ip):
         """
         GET /source/<id>
         """
-        source_file = Database.get_source(id=id)
+        source_file = Database.get_source(id=source_id)
         if not source_file:
             self.raise_exc(Forbidden, "FORBIDDEN", "You cannot get the required source")
 
@@ -76,11 +79,12 @@ class InfoHandler(BaseHandler):
 
         return BaseHandler.format_dates(source_file)
 
-    def get_submission(self, id:str, _ip):
+    @BaseHandler.during_contest
+    def get_submission(self, *, submission_id:str, _ip):
         """
         GET /submission/<id>
         """
-        submission = Database.get_submission(id)
+        submission = Database.get_submission(submission_id)
         if not submission:
             self.raise_exc(Forbidden, "FORBIDDEN", "You cannot get the required submission")
 
@@ -89,7 +93,8 @@ class InfoHandler(BaseHandler):
 
         return InfoHandler.patch_submission(submission)
 
-    def get_user(self, token:str, _ip):
+    @BaseHandler.during_contest
+    def get_user(self, *, token:str, _ip):
         """
         GET /user/<token>
         """
@@ -125,7 +130,8 @@ class InfoHandler(BaseHandler):
 
         return BaseHandler.format_dates(user, fields=["date"])
 
-    def get_submissions(self, token:str, task:str, _ip):
+    @BaseHandler.during_contest
+    def get_submissions(self, *, token:str, task:str, _ip):
         """
         GET /user/<token>/submissions/<task>
         """

--- a/src/handlers/upload_handler.py
+++ b/src/handlers/upload_handler.py
@@ -19,14 +19,15 @@ class UploadHandler(BaseHandler):
     @Validators.validate_during_contest
     @Validators.register_user_ip
     @Validators.validate_input_id
-    def upload_output(self, input, _file_content, _file_name):
+    @Validators.validate_file
+    def upload_output(self, input, file):
         """
         POST /upload_output
         """
         output_id = Database.gen_id()
-        path = StorageManager.new_output_file(output_id, _file_name)
+        path = StorageManager.new_output_file(output_id, file["name"])
 
-        StorageManager.save_file(path, _file_content)
+        StorageManager.save_file(path, file["content"])
         file_size = StorageManager.get_file_size(path)
 
         result = ContestManager.evaluate_output(input["task"], input["path"], path)
@@ -37,14 +38,15 @@ class UploadHandler(BaseHandler):
     @Validators.validate_during_contest
     @Validators.register_user_ip
     @Validators.validate_input_id
-    def upload_source(self, input, _file_content, _file_name):
+    @Validators.validate_file
+    def upload_source(self, input, file):
         """
         POST /upload_source
         """
         source_id = Database.gen_id()
-        path = StorageManager.new_source_file(source_id, _file_name)
+        path = StorageManager.new_source_file(source_id, file["name"])
 
-        StorageManager.save_file(path, _file_content)
+        StorageManager.save_file(path, file["content"])
         file_size = StorageManager.get_file_size(path)
 
         Database.add_source(source_id, input["id"], path, file_size)

--- a/src/handlers/upload_handler.py
+++ b/src/handlers/upload_handler.py
@@ -12,20 +12,17 @@ from .base_handler import BaseHandler
 from ..database import Database
 from ..storage_manager import StorageManager
 from ..contest_manager import ContestManager
-from werkzeug.exceptions import Forbidden
 
 
 class UploadHandler(BaseHandler):
 
-    @Validators.during_contest
-    @Validators.register_ip
-    @Validators.valid_input_id
-    def upload_output(self, *, _file_content, _file_name, **kwargs):
+    @Validators.validate_during_contest
+    @Validators.register_user_ip
+    @Validators.validate_input_id
+    def upload_output(self, input, _file_content, _file_name):
         """
         POST /upload_output
         """
-        input = kwargs["input"]
-
         output_id = Database.gen_id()
         path = StorageManager.new_output_file(output_id, _file_name)
 
@@ -37,15 +34,13 @@ class UploadHandler(BaseHandler):
         Database.add_output(output_id, input["id"], path, file_size, result)
         return InfoHandler.patch_output(Database.get_output(output_id))
 
-    @Validators.during_contest
-    @Validators.register_ip
-    @Validators.valid_input_id
-    def upload_source(self, *, _file_content, _file_name, **kwargs):
+    @Validators.validate_during_contest
+    @Validators.register_user_ip
+    @Validators.validate_input_id
+    def upload_source(self, input, _file_content, _file_name):
         """
         POST /upload_source
         """
-        input = kwargs["input"]
-
         source_id = Database.gen_id()
         path = StorageManager.new_source_file(source_id, _file_name)
 

--- a/src/handlers/upload_handler.py
+++ b/src/handlers/upload_handler.py
@@ -18,7 +18,7 @@ from werkzeug.exceptions import Forbidden
 class UploadHandler(BaseHandler):
 
     @BaseHandler.during_contest
-    def upload_output(self, *, input_id, _ip, _file_content, _file_name):
+    def upload_output(self, *, input_id, _ip, _file_content, _file_name, **kwargs):
         """
         POST /upload_output
         """
@@ -41,7 +41,7 @@ class UploadHandler(BaseHandler):
         return InfoHandler.patch_output(Database.get_output(output_id))
 
     @BaseHandler.during_contest
-    def upload_source(self, *, input_id, _ip, _file_content, _file_name):
+    def upload_source(self, *, input_id, _ip, _file_content, _file_name, **kwargs):
         """
         POST /upload_source
         """

--- a/src/handlers/upload_handler.py
+++ b/src/handlers/upload_handler.py
@@ -17,11 +17,12 @@ from werkzeug.exceptions import Forbidden
 
 class UploadHandler(BaseHandler):
 
-    def upload_output(self, input, _ip, _file_content, _file_name):
+    @BaseHandler.during_contest
+    def upload_output(self, *, input_id, _ip, _file_content, _file_name):
         """
         POST /upload_output
         """
-        input = Database.get_input(input)
+        input = Database.get_input(input_id)
         if input is None:
             self.raise_exc(Forbidden, "FORBIDDEN", "No such input")
 
@@ -39,11 +40,12 @@ class UploadHandler(BaseHandler):
         Database.add_output(output_id, input["id"], path, file_size, result)
         return InfoHandler.patch_output(Database.get_output(output_id))
 
-    def upload_source(self, input, _ip, _file_content, _file_name):
+    @BaseHandler.during_contest
+    def upload_source(self, *, input_id, _ip, _file_content, _file_name):
         """
         POST /upload_source
         """
-        input = Database.get_input(input)
+        input = Database.get_input(input_id)
         if input is None:
             self.raise_exc(Forbidden, "FORBIDDEN", "No such input")
 

--- a/src/handlers/upload_handler.py
+++ b/src/handlers/upload_handler.py
@@ -16,7 +16,7 @@ from ..contest_manager import ContestManager
 
 class UploadHandler(BaseHandler):
 
-    @Validators.validate_during_contest
+    @Validators.during_contest
     @Validators.register_user_ip
     @Validators.validate_input_id
     @Validators.validate_file
@@ -35,7 +35,7 @@ class UploadHandler(BaseHandler):
         Database.add_output(output_id, input["id"], path, file_size, result)
         return InfoHandler.patch_output(Database.get_output(output_id))
 
-    @Validators.validate_during_contest
+    @Validators.during_contest
     @Validators.register_user_ip
     @Validators.validate_input_id
     @Validators.validate_file

--- a/src/server.py
+++ b/src/server.py
@@ -45,10 +45,10 @@ class Server:
         # method of that handler
         self.router = Map([
             Rule("/contest", methods=["GET"], endpoint="info#get_contest"),
-            Rule("/input/<id>", methods=["GET"], endpoint="info#get_input"),
-            Rule("/output/<id>", methods=["GET"], endpoint="info#get_output"),
-            Rule("/source/<id>", methods=["GET"], endpoint="info#get_source"),
-            Rule("/submission/<id>", methods=["GET"], endpoint="info#get_submission"),
+            Rule("/input/<input_id>", methods=["GET"], endpoint="info#get_input"),
+            Rule("/output/<output_id>", methods=["GET"], endpoint="info#get_output"),
+            Rule("/source/<source_id>", methods=["GET"], endpoint="info#get_source"),
+            Rule("/submission/<submission_id>", methods=["GET"], endpoint="info#get_submission"),
             Rule("/user/<token>", methods=["GET"], endpoint="info#get_user"),
             Rule("/user/<token>/submissions/<task>", methods=["GET"], endpoint="info#get_submissions"),
             Rule("/generate_input", methods=["POST"], endpoint="contest#generate_input"),

--- a/src/validators.py
+++ b/src/validators.py
@@ -39,18 +39,9 @@ class Validators:
     @staticmethod
     def validate_file(handler):
         def handle(*args, **kwargs):
-            file = {
-                "name": kwargs["_file_name"],
-                "content": kwargs["_file_content"]
-            }
-            del kwargs["_file_name"]
-            del kwargs["_file_content"]
-            kwargs["file"] = file
             return handler(*args, **kwargs)
         BaseHandler.initialize_request_params(handle, handler)
-        BaseHandler.add_request_param(handle, "_file_name", None, True)
-        BaseHandler.add_request_param(handle, "_file_content", None, True)
-        del handle.request_params["file"]
+        BaseHandler.add_request_param(handle, "file", None, True)
         return handle
 
     @staticmethod

--- a/src/validators.py
+++ b/src/validators.py
@@ -30,6 +30,8 @@ class Validators:
     def admin_only(handler):
         @wraps(handler)
         def handle(*args, **kwargs):
+            if "admin_token" not in kwargs:
+                BaseHandler.raise_exc(Forbidden, "FORBIDDEN", "You need to provide admin_token")
             admin_token = kwargs["admin_token"]
             ip = kwargs["_ip"]
             Validators._validate_admin_token(admin_token, ip)
@@ -89,6 +91,8 @@ class Validators:
         @wraps(handler)
         def handle(*args, **kwargs):
             token = Validators._guess_token(**kwargs)
+            if "_ip" not in kwargs:
+                BaseHandler.raise_exc(BadRequest, "INVALID_CONNECTION", "Your ip cannot be detected")
             ip = kwargs["_ip"]
             if token is not None and Database.get_user(token) is not None:
                 Database.register_ip(token,  ip)

--- a/src/validators.py
+++ b/src/validators.py
@@ -115,9 +115,6 @@ class Validators:
         elif "submission_id" in kwargs:
             submission = Database.get_submission(kwargs["submission_id"])
             if submission: return submission["token"]
-        else:
-            print("I cannot guess the token from these kwargs", kwargs)
-            traceback.print_stack()
         return None
 
     @staticmethod

--- a/src/validators.py
+++ b/src/validators.py
@@ -89,14 +89,6 @@ class Validators:
         return Validators.validate_id("task", "task", Database.get_task)(handler)
 
     @staticmethod
-    def validate_presence(name, type):
-        def closure(handler):
-            BaseHandler.initialize_request_params(handler)
-            BaseHandler.add_request_param(handler, name, type)
-            return handler
-        return closure
-
-    @staticmethod
     def _guess_token(**kwargs):
         if "token" in kwargs:
             return kwargs["token"]
@@ -145,12 +137,3 @@ class Validators:
         else:
             if Database.register_admin_ip(ip):
                 Logger.warning("LOGIN_ADMIN", "An admin has connected from a new ip: %s" % ip)
-
-    @staticmethod
-    def _validate_id(param, name, getter, kwargs):
-        if param not in kwargs:
-            BaseHandler.raise_exc(BadRequest, "MISSING_PARAMETER", "You need to provide " + param)
-        thing = getter(kwargs[param])
-        if thing is None:
-            BaseHandler.raise_exc(Forbidden, "FORBIDDEN", "No such " + name)
-        kwargs[name] = thing

--- a/src/validators.py
+++ b/src/validators.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright 2017 - Edoardo Morassutto <edoardo.morassutto@gmail.com>
+import traceback
+from functools import wraps
+
+from werkzeug.exceptions import BadRequest, Forbidden
+
+from src.config import Config
+from src.database import Database
+from src.logger import Logger
+from .handlers.base_handler import BaseHandler
+
+
+class Validators:
+    @staticmethod
+    def during_contest(handler):
+        @wraps(handler)
+        def handle(*args, **kwargs):
+            token = Validators._guess_token(**kwargs)
+            Validators._ensure_contest_running(token)
+            return handler(*args, **kwargs)
+
+        return handle
+
+    @staticmethod
+    def admin_only(handler):
+        @wraps(handler)
+        def handle(*args, **kwargs):
+            admin_token = kwargs["admin_token"]
+            ip = kwargs["_ip"]
+            Validators._validate_admin_token(admin_token, ip)
+            return handler(*args, **kwargs)
+        return handle
+
+    @staticmethod
+    def valid_input_id(handler):
+        @wraps(handler)
+        def handle(*args, **kwargs):
+            Validators._validate_id("input_id", "input", Database.get_input, kwargs)
+            return handler(*args, **kwargs)
+        return handle
+
+    @staticmethod
+    def valid_output_id(handler):
+        @wraps(handler)
+        def handle(*args, **kwargs):
+            Validators._validate_id("output_id", "output", Database.get_output, kwargs)
+            return handler(*args, **kwargs)
+        return handle
+
+    @staticmethod
+    def valid_source_id(handler):
+        @wraps(handler)
+        def handle(*args, **kwargs):
+            Validators._validate_id("source_id", "source", Database.get_source, kwargs)
+            return handler(*args, **kwargs)
+        return handle
+
+    @staticmethod
+    def valid_submission_id(handler):
+        @wraps(handler)
+        def handle(*args, **kwargs):
+            Validators._validate_id("submission_id", "submission", Database.get_submission, kwargs)
+            return handler(*args, **kwargs)
+        return handle
+
+    @staticmethod
+    def valid_token(handler):
+        @wraps(handler)
+        def handle(*args, **kwargs):
+            Validators._validate_id("token", "user", Database.get_user, kwargs)
+            return handler(*args, **kwargs)
+        return handle
+
+    @staticmethod
+    def valid_task(handler):
+        @wraps(handler)
+        def handle(*args, **kwargs):
+            Validators._validate_id("task", "task", Database.get_task, kwargs)
+            return handler(*args, **kwargs)
+        return handle
+
+    @staticmethod
+    def register_ip(handler):
+        @wraps(handler)
+        def handle(*args, **kwargs):
+            token = Validators._guess_token(**kwargs)
+            ip = kwargs["_ip"]
+            if token is not None and Database.get_user(token) is not None:
+                Database.register_ip(token,  ip)
+            return handler(*args, **kwargs)
+        return handle
+
+    @staticmethod
+    def _guess_token(**kwargs):
+        if "token" in kwargs:
+            return kwargs["token"]
+        elif "input_id" in kwargs:
+            input = Database.get_input(kwargs["input_id"])
+            if input: return input["token"]
+        elif "output_id" in kwargs:
+            output = Database.get_output(kwargs["output_id"])
+            if output:
+                input = Database.get_input(output["input"])
+                if input: return input["token"]
+        elif "source_id" in kwargs:
+            source = Database.get_source(kwargs["source_id"])
+            if source:
+                input = Database.get_input(source["input"])
+                if input: return input["token"]
+        elif "submission_id" in kwargs:
+            submission = Database.get_submission(kwargs["submission_id"])
+            if submission: return submission["token"]
+        else:
+            print("I cannot guess the token from these kwargs", kwargs)
+            traceback.print_stack()
+        return None
+
+    @staticmethod
+    def _ensure_contest_running(token=None):
+        extra_time = None
+        if token:
+            user = Database.get_user(token)
+            if user:
+                extra_time = user["extra_time"]
+        if Database.get_meta("start_time") is None:
+            BaseHandler.raise_exc(Forbidden, "FORBIDDEN", "The contest has not started yet")
+        if BaseHandler.get_remaining_time(extra_time) < 0:
+            BaseHandler.raise_exc(Forbidden, "FORBIDDEN", "The contest has ended")
+
+    @staticmethod
+    def _validate_admin_token(token, ip):
+        """
+        Ensure the admin token is valid
+        :param token: Token to check
+        :param ip: IP of the client
+        """
+        if Config.admin_token == Config.default_values['admin_token']:
+            Logger.error("ADMIN", "Using default admin token!")
+        if token != Config.admin_token:
+            Logger.warning("LOGIN_ADMIN", "Admin login failed from %s" % ip)
+            BaseHandler.raise_exc(Forbidden, "FORBIDDEN", "Invalid admin token!")
+        else:
+            if Database.register_admin_ip(ip):
+                Logger.warning("LOGIN_ADMIN", "An admin has connected from a new ip: %s" % ip)
+
+    @staticmethod
+    def _validate_id(param, name, getter, kwargs):
+        if param not in kwargs:
+            BaseHandler.raise_exc(BadRequest, "MISSING_PARAMETER", "You need to provide " + param)
+        thing = getter(kwargs[param])
+        if thing is None:
+            BaseHandler.raise_exc(Forbidden, "FORBIDDEN", "No such " + name)
+        kwargs[name] = thing

--- a/test/handlers/test_admin_handler.py
+++ b/test/handlers/test_admin_handler.py
@@ -37,35 +37,35 @@ class TestAdminHandler(unittest.TestCase):
         Logger.LOG_LEVEL = self.log_backup
         Config.admin_token = self.token_backup
 
-    def test_validate_token(self):
-        self.admin_handler._validate_token('admin token', '1.2.3.4')
-
-    def test_validate_invalid_token(self):
-        with self.assertRaises(Forbidden) as ex:
-            self.admin_handler._validate_token('wrong token', '1.2.3.4')
-
-        self.assertIn("Invalid admin token", ex.exception.response.data.decode())
-
-        Logger.c.execute("SELECT * FROM logs WHERE category = 'LOGIN_ADMIN'")
-        row = Logger.c.fetchone()
-        self.assertIn("login failed", row[3])
-        self.assertIn("1.2.3.4", row[3])
-
-    def test_validate_token_log_ip(self):
-        self.admin_handler._validate_token('admin token', '1.2.3.4')
-
-        Logger.c.execute("SELECT * FROM logs WHERE category = 'LOGIN_ADMIN'")
-        row = Logger.c.fetchone()
-        self.assertIn("new ip", row[3])
-        self.assertIn("1.2.3.4", row[3])
-
-    def test_validate_token_default(self):
-        Config.admin_token = Config.default_values["admin_token"]
-        self.admin_handler._validate_token(Config.admin_token, '1.2.3.4')
-
-        Logger.c.execute("SELECT * FROM logs WHERE category = 'ADMIN'")
-        row = Logger.c.fetchone()
-        self.assertEqual("Using default admin token!", row[3])
+    # def test_validate_token(self):
+    #     self.admin_handler._validate_token('admin token', '1.2.3.4')
+    #
+    # def test_validate_invalid_token(self):
+    #     with self.assertRaises(Forbidden) as ex:
+    #         self.admin_handler._validate_token('wrong token', '1.2.3.4')
+    #
+    #     self.assertIn("Invalid admin token", ex.exception.response.data.decode())
+    #
+    #     Logger.c.execute("SELECT * FROM logs WHERE category = 'LOGIN_ADMIN'")
+    #     row = Logger.c.fetchone()
+    #     self.assertIn("login failed", row[3])
+    #     self.assertIn("1.2.3.4", row[3])
+    #
+    # def test_validate_token_log_ip(self):
+    #     self.admin_handler._validate_token('admin token', '1.2.3.4')
+    #
+    #     Logger.c.execute("SELECT * FROM logs WHERE category = 'LOGIN_ADMIN'")
+    #     row = Logger.c.fetchone()
+    #     self.assertIn("new ip", row[3])
+    #     self.assertIn("1.2.3.4", row[3])
+    #
+    # def test_validate_token_default(self):
+    #     Config.admin_token = Config.default_values["admin_token"]
+    #     self.admin_handler._validate_token(Config.admin_token, '1.2.3.4')
+    #
+    #     Logger.c.execute("SELECT * FROM logs WHERE category = 'ADMIN'")
+    #     row = Logger.c.fetchone()
+    #     self.assertEqual("Using default admin token!", row[3])
 
     @patch('src.contest_manager.ContestManager.read_from_disk')
     @patch('src.contest_manager.ContestManager.start')
@@ -73,7 +73,8 @@ class TestAdminHandler(unittest.TestCase):
         self._prepare_zip()
 
         ContestManager.has_contest = False
-        self.admin_handler.extract('admin token', 'contest.zip', 'password', '1.2.3.4')
+        self.admin_handler.extract(admin_token='admin token', filename='contest.zip',
+                                   password='password', _ip='1.2.3.4')
 
         read_mock.assert_called_once_with()
         start_mock.assert_called_once_with()
@@ -81,20 +82,23 @@ class TestAdminHandler(unittest.TestCase):
     def test_already_extracted(self):
         ContestManager.has_contest = True
         with self.assertRaises(Forbidden) as ex:
-            self.admin_handler.extract('admin token', '/foo/bar.zip', 'passwd', '1.2.3.4')
+            self.admin_handler.extract(admin_token='admin token', filename='/foo/bar.zip',
+                                       password='passwd', _ip='1.2.3.4')
 
         self.assertIn("Contest already loaded", ex.exception.response.data.decode())
 
     def test_extract_invalid_token(self):
         with self.assertRaises(Forbidden) as ex:
-            self.admin_handler.extract('invalid token', '/foo/bar.zip', 'passwd', '1.2.3.4')
+            self.admin_handler.extract(admin_token='invalid token', filename='/foo/bar.zip',
+                                       password='passwd', _ip='1.2.3.4')
 
         self.assertIn("Invalid admin token", ex.exception.response.data.decode())
 
     def test_extract_file_not_found(self):
         ContestManager.has_contest = False
         with self.assertRaises(FileNotFoundError):
-            self.admin_handler.extract('admin token', '/foo/bar.zip', 'passwd', '1.2.3.4')
+            self.admin_handler.extract(admin_token='admin token', filename='/foo/bar.zip',
+                                       password='passwd', _ip='1.2.3.4')
 
     @patch('src.contest_manager.ContestManager.read_from_disk')
     @patch('src.contest_manager.ContestManager.start')
@@ -102,12 +106,14 @@ class TestAdminHandler(unittest.TestCase):
         self._prepare_zip()
 
         with self.assertRaises(RuntimeError) as ex:
-            self.admin_handler.extract('admin token', 'contest.zip', "passwd", '1.2.3.4')
+            self.admin_handler.extract(admin_token='admin token', filename='contest.zip',
+                                       password="passwd", _ip='1.2.3.4')
         self.assertIn("Bad password", ex.exception.args[0])
 
     def test_log_invalid_token(self):
         with self.assertRaises(Forbidden) as ex:
-            self.admin_handler.log(None, None, None, 'invalid token', None, None)
+            self.admin_handler.log(start_date=None, end_date=None, level=None,
+                                   category=None, admin_token='invalid token', _ip=None)
 
         self.assertIn("Invalid admin token", ex.exception.response.data.decode())
 
@@ -117,7 +123,8 @@ class TestAdminHandler(unittest.TestCase):
         start_date = datetime.datetime.fromtimestamp(datetime.datetime.now().timestamp() - 10).isoformat()
         end_date = datetime.datetime.fromtimestamp(datetime.datetime.now().timestamp() + 10).isoformat()
 
-        res = self.admin_handler.log(start_date, end_date, 'WARNING', 'admin token', '1.2.3.4')
+        res = self.admin_handler.log(start_date=start_date, end_date=end_date, level='WARNING',
+                                     admin_token='admin token', _ip='1.2.3.4')
         self.assertEqual(3, len(res["items"])) # NOTE: there is also the LOGIN_ADMIN row
 
     def test_log_category(self):
@@ -126,16 +133,18 @@ class TestAdminHandler(unittest.TestCase):
         start_date = datetime.datetime.fromtimestamp(datetime.datetime.now().timestamp() - 10).isoformat()
         end_date = datetime.datetime.fromtimestamp(datetime.datetime.now().timestamp() + 10).isoformat()
 
-        res = self.admin_handler.log(start_date, end_date, 'DEBUG', 'admin token', '1.2.3.4', 'CATEGORY')
+        res = self.admin_handler.log(start_date=start_date, end_date=end_date, level='DEBUG',
+                                     admin_token='admin token', _ip='1.2.3.4', category='CATEGORY')
         self.assertEqual(2, len(res["items"]))
 
     def test_log_invalid_level(self):
         with self.assertRaises(BadRequest):
-            self.admin_handler.log(None, None, 'NOT-EXISTING-LEVEL', 'admin token', '1.2.3.4')
+            self.admin_handler.log(start_date=None, end_date=None, level='NOT-EXISTING-LEVEL',
+                                   admin_token='admin token', _ip='1.2.3.4')
 
     def test_start_invalid_token(self):
         with self.assertRaises(Forbidden) as ex:
-            self.admin_handler.start('invalid token', None)
+            self.admin_handler.start(admin_token='invalid token', _ip=None)
 
         self.assertIn("Invalid admin token", ex.exception.response.data.decode())
 
@@ -143,12 +152,12 @@ class TestAdminHandler(unittest.TestCase):
         Database.set_meta('start_time', 12345)
 
         with self.assertRaises(Forbidden) as ex:
-            self.admin_handler.start('admin token', '1.2.3.4')
+            self.admin_handler.start(admin_token='admin token', _ip='1.2.3.4')
 
         self.assertIn("Contest has already been started", ex.exception.response.data.decode())
 
     def test_start_ok(self):
-        out = self.admin_handler.start('admin token', '1.2.3.4')
+        out = self.admin_handler.start(admin_token='admin token', _ip='1.2.3.4')
 
         start_time = datetime.datetime.strptime(out["start_time"], "%Y-%m-%dT%H:%M:%S").timestamp()
         self.assertTrue(start_time >= datetime.datetime.now().timestamp() - 10)
@@ -157,32 +166,32 @@ class TestAdminHandler(unittest.TestCase):
 
     def test_set_extra_time_invalid_token(self):
         with self.assertRaises(Forbidden) as ex:
-            self.admin_handler.set_extra_time('invalid token', None, None)
+            self.admin_handler.set_extra_time(admin_token='invalid token', extra_time=None, _ip=None)
 
         self.assertIn("Invalid admin token", ex.exception.response.data.decode())
 
     def test_set_extra_time_global(self):
-        self.admin_handler.set_extra_time('admin token', 42, '1.2.3.4')
+        self.admin_handler.set_extra_time(admin_token='admin token', extra_time=42, _ip='1.2.3.4')
 
         self.assertEqual(42, Database.get_meta('extra_time', type=int))
 
     def test_set_extra_time_user(self):
         Database.c.execute("INSERT INTO users (token, name, surname, extra_time) VALUES ('user token', 'a', 'b', 0)")
 
-        self.admin_handler.set_extra_time('admin token', 42, '1.2.3.4', 'user token')
+        self.admin_handler.set_extra_time(admin_token='admin token', extra_time=42, _ip='1.2.3.4', token='user token')
 
         user = Database.get_user('user token')
         self.assertEqual(42, user["extra_time"])
 
     def test_status_invalid_token(self):
         with self.assertRaises(Forbidden) as ex:
-            self.admin_handler.status('invalid token', None)
+            self.admin_handler.status(admin_token='invalid token', _ip=None)
 
         self.assertIn("Invalid admin token", ex.exception.response.data.decode())
 
     def test_status(self):
         Database.set_meta('start_time', 1234)
-        res = self.admin_handler.status('admin token', '1.2.3.4')
+        res = self.admin_handler.status(admin_token='admin token', _ip='1.2.3.4')
 
         start_time = int(datetime.datetime.strptime(res["start_time"], "%Y-%m-%dT%H:%M:%S").timestamp())
 
@@ -191,7 +200,7 @@ class TestAdminHandler(unittest.TestCase):
 
     def test_user_list_invalid_token(self):
         with self.assertRaises(Forbidden) as ex:
-            self.admin_handler.user_list('invalid token', None)
+            self.admin_handler.user_list(admin_token='invalid token', _ip=None)
 
         self.assertIn("Invalid admin token", ex.exception.response.data.decode())
 
@@ -201,7 +210,7 @@ class TestAdminHandler(unittest.TestCase):
         Database.register_ip("token", "1.2.3.4")
         Database.register_ip("token", "1.2.3.5")
 
-        res = self.admin_handler.user_list('admin token', None)
+        res = self.admin_handler.user_list(admin_token='admin token', _ip=None)
         self.assertEqual(2, len(res["items"]))
         user1 = next(i for i in res["items"] if i["token"] == "token")
         user2 = next(i for i in res["items"] if i["token"] == "token2")

--- a/test/handlers/test_admin_handler.py
+++ b/test/handlers/test_admin_handler.py
@@ -37,36 +37,6 @@ class TestAdminHandler(unittest.TestCase):
         Logger.LOG_LEVEL = self.log_backup
         Config.admin_token = self.token_backup
 
-    # def test_validate_token(self):
-    #     self.admin_handler._validate_token('admin token', '1.2.3.4')
-    #
-    # def test_validate_invalid_token(self):
-    #     with self.assertRaises(Forbidden) as ex:
-    #         self.admin_handler._validate_token('wrong token', '1.2.3.4')
-    #
-    #     self.assertIn("Invalid admin token", ex.exception.response.data.decode())
-    #
-    #     Logger.c.execute("SELECT * FROM logs WHERE category = 'LOGIN_ADMIN'")
-    #     row = Logger.c.fetchone()
-    #     self.assertIn("login failed", row[3])
-    #     self.assertIn("1.2.3.4", row[3])
-    #
-    # def test_validate_token_log_ip(self):
-    #     self.admin_handler._validate_token('admin token', '1.2.3.4')
-    #
-    #     Logger.c.execute("SELECT * FROM logs WHERE category = 'LOGIN_ADMIN'")
-    #     row = Logger.c.fetchone()
-    #     self.assertIn("new ip", row[3])
-    #     self.assertIn("1.2.3.4", row[3])
-    #
-    # def test_validate_token_default(self):
-    #     Config.admin_token = Config.default_values["admin_token"]
-    #     self.admin_handler._validate_token(Config.admin_token, '1.2.3.4')
-    #
-    #     Logger.c.execute("SELECT * FROM logs WHERE category = 'ADMIN'")
-    #     row = Logger.c.fetchone()
-    #     self.assertEqual("Using default admin token!", row[3])
-
     @patch('src.contest_manager.ContestManager.read_from_disk')
     @patch('src.contest_manager.ContestManager.start')
     def test_extract(self, start_mock, read_mock):

--- a/test/handlers/test_admin_handler.py
+++ b/test/handlers/test_admin_handler.py
@@ -134,11 +134,17 @@ class TestAdminHandler(unittest.TestCase):
 
         self.assertEqual(start_time, Database.get_meta('start_time', type=int))
 
-    def test_set_extra_time_invalid_token(self):
+    def test_set_extra_time_invalid_admin_token(self):
         with self.assertRaises(Forbidden) as ex:
             self.admin_handler.set_extra_time(admin_token='invalid token', extra_time=None, _ip=None)
 
         self.assertIn("Invalid admin token", ex.exception.response.data.decode())
+
+    def test_set_extra_time_invalid_token(self):
+        with self.assertRaises(Forbidden) as ex:
+            self.admin_handler.set_extra_time(admin_token='admin token', extra_time=42, token="foobar", _ip=None)
+
+        self.assertIn("No such user", ex.exception.response.data.decode())
 
     def test_set_extra_time_global(self):
         self.admin_handler.set_extra_time(admin_token='admin token', extra_time=42, _ip='1.2.3.4')

--- a/test/handlers/test_base_handler.py
+++ b/test/handlers/test_base_handler.py
@@ -226,12 +226,6 @@ class TestBaseHandler(unittest.TestCase):
         res = handler._call(handler.file, {}, request)
         self.assertEqual("foo", res)
 
-
-
-
-
-
-
     def test_get_file_name(self):
         request = Request(Environ())
         request.files = { "file": FileStorage(filename="foo") }

--- a/test/handlers/test_base_handler.py
+++ b/test/handlers/test_base_handler.py
@@ -41,11 +41,13 @@ class TestBaseHandler(unittest.TestCase):
         self.assertEqual("Ex message", data["message"])
 
     class DummyHandler(BaseHandler):
-        def dummy_endpoint(self, *, param:int=123, **kwargs):
+        def dummy_endpoint(self, param:int=123):
             return {"incremented": param+1}
-        def required(self, *, param, **kwargs):
+
+        def required(self, param):
             self.raise_exc(Forbidden, 'NOBUONO', 'nononono')
-        def myip(self, *, _ip, **kwargs):
+
+        def myip(self, _ip):
             return _ip
 
     @patch('src.handlers.base_handler.BaseHandler._call', return_value={'foo': 'bar'})

--- a/test/handlers/test_base_handler.py
+++ b/test/handlers/test_base_handler.py
@@ -22,6 +22,7 @@ from src.config import Config
 from src.database import Database
 from src.handlers.base_handler import BaseHandler
 from src.logger import Logger
+from src.validators import Validators
 from test.utils import Utils
 
 
@@ -52,6 +53,11 @@ class TestBaseHandler(unittest.TestCase):
 
         def file(self, file):
             return file["name"]
+
+        @Validators.validate_input_id
+        @Validators.validate_output_id
+        def with_decorators(self, input, output):
+            pass
 
     @patch('src.handlers.base_handler.BaseHandler._call', return_value={'foo': 'bar'})
     def test_handle(self, call_mock):
@@ -225,6 +231,17 @@ class TestBaseHandler(unittest.TestCase):
 
         res = handler._call(handler.file, {}, request)
         self.assertEqual("foo", res)
+
+    def test_call_with_decorators(self):
+        handler = TestBaseHandler.DummyHandler()
+        env = Environ({"wsgi.input": None})
+        request = Request(env)
+        Database.add_user("token", "", "")
+        Database.add_task("poldo", "", "", 1, 1)
+        Database.add_input("inputid", "token", "poldo", 1, "", 42)
+        Database.add_output("outputid", "inputid", "", 42, "")
+
+        handler._call(handler.with_decorators, {"input_id": "inputid", "output_id":"outputid"}, request)
 
     def test_get_file_name(self):
         request = Request(Environ())

--- a/test/handlers/test_base_handler.py
+++ b/test/handlers/test_base_handler.py
@@ -29,11 +29,6 @@ class TestBaseHandler(unittest.TestCase):
     def setUp(self):
         Utils.prepare_test()
         self.handler = BaseHandler()
-        self.token_backup = Config.admin_token
-        Config.admin_token = 'admin token'
-
-        self.log_backup = Logger.LOG_LEVEL
-        Logger.LOG_LEVEL = 9001 # disable the logs
 
     def test_raise_exc(self):
         with self.assertRaises(Forbidden) as ex:
@@ -88,11 +83,11 @@ class TestBaseHandler(unittest.TestCase):
         Database.set_meta("contest_duration", 150)
         Database.set_meta("extra_time", 20)
 
-        self.assertAlmostEqual(BaseHandler._get_remaining_time(20), 90, delta=1)
-        self.assertAlmostEqual(BaseHandler._get_remaining_time(0), 70, delta=1)
+        self.assertAlmostEqual(BaseHandler.get_remaining_time(20), 90, delta=1)
+        self.assertAlmostEqual(BaseHandler.get_remaining_time(0), 70, delta=1)
 
     def test_remaining_time_not_started(self):
-        self.assertIsNone(BaseHandler._get_remaining_time(0))
+        self.assertIsNone(BaseHandler.get_remaining_time(0))
 
     def test_format_dates(self):
         dct = {
@@ -258,33 +253,3 @@ class TestBaseHandler(unittest.TestCase):
 
         ip = BaseHandler.get_ip(request)
         self.assertEqual("1.2.3.4", ip)
-
-    def test_validate_token(self):
-        BaseHandler.validate_admin_token('admin token', '1.2.3.4')
-
-    def test_validate_invalid_token(self):
-        with self.assertRaises(Forbidden) as ex:
-            BaseHandler.validate_admin_token('wrong token', '1.2.3.4')
-
-        self.assertIn("Invalid admin token", ex.exception.response.data.decode())
-
-        Logger.c.execute("SELECT * FROM logs WHERE category = 'LOGIN_ADMIN'")
-        row = Logger.c.fetchone()
-        self.assertIn("login failed", row[3])
-        self.assertIn("1.2.3.4", row[3])
-
-    def test_validate_token_log_ip(self):
-        BaseHandler.validate_admin_token('admin token', '1.2.3.4')
-
-        Logger.c.execute("SELECT * FROM logs WHERE category = 'LOGIN_ADMIN'")
-        row = Logger.c.fetchone()
-        self.assertIn("new ip", row[3])
-        self.assertIn("1.2.3.4", row[3])
-
-    def test_validate_token_default(self):
-        Config.admin_token = Config.default_values["admin_token"]
-        BaseHandler.validate_admin_token(Config.admin_token, '1.2.3.4')
-
-        Logger.c.execute("SELECT * FROM logs WHERE category = 'ADMIN'")
-        row = Logger.c.fetchone()
-        self.assertEqual("Using default admin token!", row[3])

--- a/test/handlers/test_base_handler.py
+++ b/test/handlers/test_base_handler.py
@@ -50,6 +50,9 @@ class TestBaseHandler(unittest.TestCase):
         def myip(self, _ip):
             return _ip
 
+        def file(self, file):
+            return file["name"]
+
     @patch('src.handlers.base_handler.BaseHandler._call', return_value={'foo': 'bar'})
     def test_handle(self, call_mock):
         handler = TestBaseHandler.DummyHandler()
@@ -213,6 +216,21 @@ class TestBaseHandler(unittest.TestCase):
 
         res = handler._call(handler.myip, {}, request)
         self.assertEqual("1.2.3.4", res)
+
+    def test_call_file(self):
+        handler = TestBaseHandler.DummyHandler()
+        env = Environ({"wsgi.input": None})
+        request = Request(env)
+        request.files = {"file": FileStorage(filename="foo")}
+
+        res = handler._call(handler.file, {}, request)
+        self.assertEqual("foo", res)
+
+
+
+
+
+
 
     def test_get_file_name(self):
         request = Request(Environ())

--- a/test/handlers/test_contest_handler.py
+++ b/test/handlers/test_contest_handler.py
@@ -47,48 +47,53 @@ class TestContestHandler(unittest.TestCase):
         self.assertEqual(40, row[0])
 
     def test_generate_input_invalid_token(self):
+        Utils.start_contest()
         self._insert_data()
 
         with self.assertRaises(Forbidden) as ex:
-            self.handler.generate_input('invalid token', 'poldo', '1.1.1.1')
+            self.handler.generate_input(token='invalid token', task='poldo', _ip='1.1.1.1')
 
         self.assertIn("No such user", ex.exception.response.data.decode())
 
     def test_generate_input_invalid_task(self):
+        Utils.start_contest()
         self._insert_data()
 
         with self.assertRaises(Forbidden) as ex:
-            self.handler.generate_input('token', 'invalid task', '1.1.1.1')
+            self.handler.generate_input(token='token', task='invalid task', _ip='1.1.1.1')
 
         self.assertIn("No such task", ex.exception.response.data.decode())
 
     @patch("src.contest_manager.ContestManager.get_input", return_value=('inputid', '/path'))
     @patch("src.storage_manager.StorageManager.get_file_size", return_value=42)
     def test_generate_input_already_have(self, get_file_size_mock, get_input_mock):
+        Utils.start_contest()
         self._insert_data()
-        self.handler.generate_input('token', 'poldo', '1.1.1.1')
+        self.handler.generate_input(token='token', task='poldo', _ip='1.1.1.1')
 
         with self.assertRaises(Forbidden) as ex:
-            self.handler.generate_input('token', 'poldo', '1.1.1.1')
+            self.handler.generate_input(token='token', task='poldo', _ip='1.1.1.1')
 
         self.assertIn("You already have a ready input", ex.exception.response.data.decode())
 
     @patch("src.contest_manager.ContestManager.get_input", return_value=('inputid', '/path'))
     @patch("src.storage_manager.StorageManager.get_file_size", return_value=42)
-    @patch("src.database.Database.commit", side_effect=Exception("ops..."))
     @patch("src.database.Database.register_ip", return_value=None)
-    def test_generate_input_transaction_broken(self, register_mock, commit_mock, get_file_size_mock, get_input_mock):
+    def test_generate_input_transaction_broken(self, register_mock, get_file_size_mock, get_input_mock):
+        Utils.start_contest()
         self._insert_data()
         with self.assertRaises(Exception) as ex:
-            self.handler.generate_input('token', 'poldo', '1.1.1.1')
+            with patch("src.database.Database.commit", side_effect=Exception("ops...")):
+                self.handler.generate_input(token='token', task='poldo', _ip='1.1.1.1')
         self.assertIn("ops...", ex.exception.args[0])
         self.assertIsNone(Database.get_input("inputid"))
 
     @patch("src.contest_manager.ContestManager.get_input", return_value=('inputid', '/path'))
     @patch("src.storage_manager.StorageManager.get_file_size", return_value=42)
     def test_generate_input(self, get_file_size_mock, get_input_mock):
+        Utils.start_contest()
         self._insert_data()
-        response = self.handler.generate_input('token', 'poldo', '1.1.1.1')
+        response = self.handler.generate_input(token='token', task='poldo', _ip='1.1.1.1')
 
         self.assertEqual("inputid", response["id"])
         self.assertEqual("/path", response["path"])
@@ -104,44 +109,47 @@ class TestContestHandler(unittest.TestCase):
         self.assertEqual(1, row[3])
 
     def test_submit_invalid_output(self):
+        Utils.start_contest()
         self._insert_data()
 
         with self.assertRaises(Forbidden) as ex:
-            self.handler.submit('invalid output', 'invalid source', '1.1.1.1')
+            self.handler.submit(output_id='invalid output', source_id='invalid source', _ip='1.1.1.1')
 
         self.assertIn("No such output file", ex.exception.response.data.decode())
 
     @patch("src.contest_manager.ContestManager.get_input", return_value=('inputid', '/path'))
     @patch("src.storage_manager.StorageManager.get_file_size", return_value=42)
     def test_sumbit_invalid_source(self, g_f_s_mock, g_i_mock):
+        Utils.start_contest()
         self._insert_data()
 
-        self.handler.generate_input('token', 'poldo', '1.1.1.1')
+        self.handler.generate_input(token='token', task='poldo', _ip='1.1.1.1')
         Database.c.execute("INSERT INTO outputs (id, input, path, size, result) "
                            "VALUES ('outputid', 'inputid', '/output', 42, '{}')")
         with self.assertRaises(Forbidden) as ex:
-            self.handler.submit('outputid', 'invalid source', '1.1.1.1')
+            self.handler.submit(output_id='outputid', source_id='invalid source', _ip='1.1.1.1')
 
         self.assertIn("No such source file", ex.exception.response.data.decode())
 
     @patch("src.contest_manager.ContestManager.get_input", return_value=("inputid", '/path'))
     @patch("src.storage_manager.StorageManager.get_file_size", return_value=42)
     def test_sumbit_not_matching(self, g_f_s_mock, g_i_mock):
+        Utils.start_contest()
         self._insert_data(token="token", task="poldo")
         self._insert_data(token="token2", task="poldo")
         backup = Logger.LOG_LEVEL
         Logger.LOG_LEVEL = 9001
 
-        self.handler.generate_input('token', 'poldo', '1.1.1.1')
+        self.handler.generate_input(token='token', task='poldo', _ip='1.1.1.1')
         g_i_mock.return_value = ("inputid2", "/path")
-        self.handler.generate_input('token2', 'poldo', '1.1.1.1')
+        self.handler.generate_input(token='token2', task='poldo', _ip='1.1.1.1')
 
         Database.c.execute("INSERT INTO outputs (id, input, path, size, result) "
                            "VALUES ('outputid', 'inputid', '/output', 42, '{}')")
         Database.c.execute("INSERT INTO sources (id, input, path, size) "
                            "VALUES ('sourceid', 'inputid2', '/source', 42)")
         with self.assertRaises(Forbidden) as ex:
-            self.handler.submit('outputid', 'sourceid', '1.1.1.1')
+            self.handler.submit(output_id='outputid', source_id='sourceid', _ip='1.1.1.1')
 
         self.assertIn("The provided pair of source-output is invalid", ex.exception.response.data.decode())
         Logger.LOG_LEVEL = backup
@@ -149,8 +157,9 @@ class TestContestHandler(unittest.TestCase):
     @patch("src.contest_manager.ContestManager.get_input", return_value=("inputid", '/path'))
     @patch("src.storage_manager.StorageManager.get_file_size", return_value=42)
     def test_submit_db_broken(self, g_i_mock, g_f_s_mock):
+        Utils.start_contest()
         self._insert_data()
-        self.handler.generate_input('token', 'poldo', '1.1.1.1')
+        self.handler.generate_input(token='token', task='poldo', _ip='1.1.1.1')
         Database.c.execute("INSERT INTO outputs (id, input, path, size, result) "
                            "VALUES ('outputid', 'inputid', '/output', 42,"
                            "'{\"score\":0.5,\"feedback\":{\"a\":1},\"validation\":{\"b\":2}}')")
@@ -159,7 +168,7 @@ class TestContestHandler(unittest.TestCase):
         with patch("src.database.Database.get_input", return_value=None):
             with Utils.nostderr() as stderr:
                 with self.assertRaises(BadRequest) as ex:
-                    self.handler.submit('outputid', 'sourceid', '1.1.1.1')
+                    self.handler.submit(output_id='outputid', source_id='sourceid', _ip='1.1.1.1')
         self.assertIn("DB_CONSISTENCY_ERROR", stderr.buffer)
         self.assertIn("Input inputid not found in the db", stderr.buffer)
         self.assertIn("WRONG_INPUT", ex.exception.response.data.decode())
@@ -170,8 +179,9 @@ class TestContestHandler(unittest.TestCase):
     @patch("src.contest_manager.ContestManager.get_input", return_value=("inputid", '/path'))
     @patch("src.storage_manager.StorageManager.get_file_size", return_value=42)
     def test_submit_broken_transaction(self, gen_i_mock, a_s_mock, g_f_s_mock, g_i_mock):
+        Utils.start_contest()
         self._insert_data()
-        self.handler.generate_input('token', 'poldo', '1.1.1.1')
+        self.handler.generate_input(token='token', task='poldo', _ip='1.1.1.1')
 
         Database.c.execute("INSERT INTO outputs (id, input, path, size, result) "
                            "VALUES ('outputid', 'inputid', '/output', 42,"
@@ -180,15 +190,16 @@ class TestContestHandler(unittest.TestCase):
                            "VALUES ('sourceid', 'inputid', '/source', 42)")
 
         with self.assertRaises(BadRequest) as ex:
-            self.handler.submit('outputid', 'sourceid', '1.1.1.1')
+            self.handler.submit(output_id='outputid', source_id='sourceid', _ip='1.1.1.1')
         self.assertIn("Error inserting the submission", ex.exception.response.data.decode())
         self.assertIsNone(Database.get_submission("subid"))
 
     @patch("src.contest_manager.ContestManager.get_input", return_value=("inputid", '/path'))
     @patch("src.storage_manager.StorageManager.get_file_size", return_value=42)
     def test_submit(self, g_f_s_mock, g_i_mock):
+        Utils.start_contest()
         self._insert_data()
-        self.handler.generate_input('token', 'poldo', '1.1.1.1')
+        self.handler.generate_input(token='token', task='poldo', _ip='1.1.1.1')
 
         Database.c.execute("INSERT INTO outputs (id, input, path, size, result) "
                            "VALUES ('outputid', 'inputid', '/output', 42,"
@@ -196,7 +207,7 @@ class TestContestHandler(unittest.TestCase):
         Database.c.execute("INSERT INTO sources (id, input, path, size) "
                            "VALUES ('sourceid', 'inputid', '/source', 42)")
 
-        response = self.handler.submit('outputid', 'sourceid', '1.1.1.1')
+        response = self.handler.submit(output_id='outputid', source_id='sourceid', _ip='1.1.1.1')
         self.assertEqual("token", response["token"])
         self.assertEqual("poldo", response["task"])
         self.assertEqual(21, response["score"])

--- a/test/handlers/test_contest_handler.py
+++ b/test/handlers/test_contest_handler.py
@@ -115,7 +115,7 @@ class TestContestHandler(unittest.TestCase):
         with self.assertRaises(Forbidden) as ex:
             self.handler.submit(output_id='invalid output', source_id='invalid source', _ip='1.1.1.1')
 
-        self.assertIn("No such output file", ex.exception.response.data.decode())
+        self.assertIn("No such output", ex.exception.response.data.decode())
 
     @patch("src.contest_manager.ContestManager.get_input", return_value=('inputid', '/path'))
     @patch("src.storage_manager.StorageManager.get_file_size", return_value=42)
@@ -129,7 +129,7 @@ class TestContestHandler(unittest.TestCase):
         with self.assertRaises(Forbidden) as ex:
             self.handler.submit(output_id='outputid', source_id='invalid source', _ip='1.1.1.1')
 
-        self.assertIn("No such source file", ex.exception.response.data.decode())
+        self.assertIn("No such source", ex.exception.response.data.decode())
 
     @patch("src.contest_manager.ContestManager.get_input", return_value=("inputid", '/path'))
     @patch("src.storage_manager.StorageManager.get_file_size", return_value=42)

--- a/test/handlers/test_info_handler.py
+++ b/test/handlers/test_info_handler.py
@@ -39,15 +39,17 @@ class TestInfoHandler(unittest.TestCase):
         Database.add_user("token", "", "")
         Database.add_task("poldo", "", "", 42, 1)
         Database.add_input("inputid", "token", "poldo", 1, "/path", 42)
+        Utils.start_contest()
 
-        res = self.handler.get_input("inputid", "1.1.1.1")
+        res = self.handler.get_input(input_id="inputid", _ip="1.1.1.1")
         self.assertEqual("inputid", res["id"])
         self.assertEqual("token", res["token"])
         self.assertEqual("poldo", res["task"])
 
     def test_get_input_invalid_id(self):
+        Utils.start_contest()
         with self.assertRaises(Forbidden) as ex:
-            self.handler.get_input("invalid input", "1.1.1.1")
+            self.handler.get_input(input_id="invalid input", _ip="1.1.1.1")
 
         response = ex.exception.response.data.decode()
         self.assertIn("You cannot get the required input", response)
@@ -57,35 +59,40 @@ class TestInfoHandler(unittest.TestCase):
         Database.add_task("poldo", "", "", 42, 1)
         Database.add_input("inputid", "token", "poldo", 1, "/path", 42)
         Database.add_output("outputid", "inputid", "/path", 42, '{"validation":42}')
+        Utils.start_contest()
 
-        res = self.handler.get_output("outputid", "1.1.1.1")
+        res = self.handler.get_output(output_id="outputid", _ip="1.1.1.1")
         self.assertEqual("outputid", res["id"])
         self.assertEqual(42, res["validation"])
 
     def test_get_output_invalid_id(self):
+        Utils.start_contest()
         with self.assertRaises(Forbidden) as ex:
-            self.handler.get_output("invalid output", "1.1.1.1")
+            self.handler.get_output(output_id="invalid output", _ip="1.1.1.1")
 
         response = ex.exception.response.data.decode()
         self.assertIn("You cannot get the required output", response)
 
     def test_get_source(self):
+        Utils.start_contest()
         Database.add_user("token", "", "")
         Database.add_task("poldo", "", "", 42, 1)
         Database.add_input("inputid", "token", "poldo", 1, "/path", 42)
         Database.add_source("sourceid", "inputid", "/path", 42)
 
-        res = self.handler.get_source("sourceid", "1.1.1.1")
+        res = self.handler.get_source(source_id="sourceid", _ip="1.1.1.1")
         self.assertEqual("sourceid", res["id"])
 
     def test_get_source_invalid_id(self):
+        Utils.start_contest()
         with self.assertRaises(Forbidden) as ex:
-            self.handler.get_source("invalid source", "1.1.1.1")
+            self.handler.get_source(source_id="invalid source", _ip="1.1.1.1")
 
         response = ex.exception.response.data.decode()
         self.assertIn("You cannot get the required source", response)
 
     def test_get_submission(self):
+        Utils.start_contest()
         Database.add_user("token", "", "")
         Database.add_task("poldo", "", "", 42, 1)
         Database.add_input("inputid", "token", "poldo", 1, "/path", 42)
@@ -93,7 +100,7 @@ class TestInfoHandler(unittest.TestCase):
         Database.add_source("sourceid", "inputid", "/path", 42)
         Database.add_submission("subid", "inputid", "outputid", "sourceid", 42)
 
-        res = self.handler.get_submission("subid", "1.1.1.1")
+        res = self.handler.get_submission(submission_id="subid", _ip="1.1.1.1")
         self.assertEqual("subid", res["id"])
         self.assertEqual("inputid", res["input"]["id"])
         self.assertEqual("outputid", res["output"]["id"])
@@ -101,22 +108,23 @@ class TestInfoHandler(unittest.TestCase):
         self.assertEqual(42, res["feedback"])
 
     def test_get_submission_invalid_id(self):
+        Utils.start_contest()
         with self.assertRaises(Forbidden) as ex:
-            self.handler.get_submission("invalid submission", "1.1.1.1")
+            self.handler.get_submission(submission_id="invalid submission", _ip="1.1.1.1")
 
         response = ex.exception.response.data.decode()
         self.assertIn("You cannot get the required submission", response)
 
     def test_get_user_invalid_token(self):
+        Utils.start_contest()
         with self.assertRaises(Forbidden) as ex:
-            self.handler.get_user("invalid token", "1.1.1.1")
+            self.handler.get_user(token="invalid token", _ip="1.1.1.1")
 
         response = ex.exception.response.data.decode()
         self.assertIn("Invalid login", response)
 
     def test_get_user(self):
-        Database.set_meta("start_time", int(datetime.datetime.now().timestamp() - 100))
-        Database.set_meta("contest_duration", 200)
+        Utils.start_contest(since=100, duration=200)
         Database.set_meta("extra_time", 50)
         Database.add_user("token", "", "")
         Database.set_extra_time("token", 30)
@@ -125,22 +133,22 @@ class TestInfoHandler(unittest.TestCase):
         Database.add_input("inputid", "token", "poldo", 1, "/path", 42)
         Database.set_user_attempt("token", "poldo", 1)
 
-        res = self.handler.get_user("token", "1.1.1.1")
+        res = self.handler.get_user(token="token", _ip="1.1.1.1")
         self.assertEqual(180, res["remaining_time"])
         self.assertEqual("poldo", res["tasks"]["poldo"]["name"])
         self.assertEqual("inputid", res["tasks"]["poldo"]["current_input"]["id"])
 
     def test_get_user_no_current_attempt(self):
-        Database.set_meta("start_time", int(datetime.datetime.now().timestamp() - 100))
-        Database.set_meta("contest_duration", 200)
+        Utils.start_contest(since=100, duration=200)
         Database.add_user("token", "", "")
         Database.add_task("poldo", "", "", 42, 1)
         Database.add_user_task("token", "poldo")
 
-        res = self.handler.get_user("token", "1.1.1.1")
+        res = self.handler.get_user(token="token", _ip="1.1.1.1")
         self.assertEqual(None, res["tasks"]["poldo"]["current_input"])
 
     def test_get_submissions(self):
+        Utils.start_contest()
         Database.add_user("token", "", "")
         Database.add_task("poldo", "", "", 42, 1)
         Database.add_input("inputid", "token", "poldo", 1, "/path", 42)
@@ -148,27 +156,30 @@ class TestInfoHandler(unittest.TestCase):
         Database.add_source("sourceid", "inputid", "/path", 42)
         Database.add_submission("subid", "inputid", "outputid", "sourceid", 42)
 
-        res = self.handler.get_submissions("token", "poldo", "1.1.1.1")
+        res = self.handler.get_submissions(token="token", task="poldo", _ip="1.1.1.1")
         self.assertEqual(1, len(res["items"]))
         self.assertEqual("subid", res["items"][0]["id"])
 
     def test_get_submissions_invalid_token(self):
+        Utils.start_contest()
         with self.assertRaises(Forbidden) as ex:
-            self.handler.get_submissions("invalid token", "poldo", "1.1.1.1")
+            self.handler.get_submissions(token="invalid token", task="poldo", _ip="1.1.1.1")
 
         response = ex.exception.response.data.decode()
         self.assertIn("Invalid login", response)
 
     def test_get_submissions_invalid_task(self):
+        Utils.start_contest()
         Database.add_user("token", "", "")
         with self.assertRaises(Forbidden) as ex:
-            self.handler.get_submissions("token", "invalid task", "1.1.1.1")
+            self.handler.get_submissions(token="token", task="invalid task", _ip="1.1.1.1")
 
         response = ex.exception.response.data.decode()
         self.assertIn("Invalid task", response)
 
     @patch("src.handlers.info_handler.InfoHandler.patch_output", return_value={"id":"outputid"})
     def test_patch_submission(self, mock):
+        Utils.start_contest()
         submission = {
             "id": "subid",
             "nested_item": 42,
@@ -182,6 +193,7 @@ class TestInfoHandler(unittest.TestCase):
         self.assertEqual("outputid", res["output"]["id"])
 
     def test_patch_output(self):
+        Utils.start_contest()
         output = {
             "id": "outputid",
             "date": 1234,

--- a/test/handlers/test_info_handler.py
+++ b/test/handlers/test_info_handler.py
@@ -52,7 +52,7 @@ class TestInfoHandler(unittest.TestCase):
             self.handler.get_input(input_id="invalid input", _ip="1.1.1.1")
 
         response = ex.exception.response.data.decode()
-        self.assertIn("You cannot get the required input", response)
+        self.assertIn("No such input", response)
 
     def test_get_output(self):
         Database.add_user("token", "", "")
@@ -71,7 +71,7 @@ class TestInfoHandler(unittest.TestCase):
             self.handler.get_output(output_id="invalid output", _ip="1.1.1.1")
 
         response = ex.exception.response.data.decode()
-        self.assertIn("You cannot get the required output", response)
+        self.assertIn("No such output", response)
 
     def test_get_source(self):
         Utils.start_contest()
@@ -89,7 +89,7 @@ class TestInfoHandler(unittest.TestCase):
             self.handler.get_source(source_id="invalid source", _ip="1.1.1.1")
 
         response = ex.exception.response.data.decode()
-        self.assertIn("You cannot get the required source", response)
+        self.assertIn("No such source", response)
 
     def test_get_submission(self):
         Utils.start_contest()
@@ -113,7 +113,7 @@ class TestInfoHandler(unittest.TestCase):
             self.handler.get_submission(submission_id="invalid submission", _ip="1.1.1.1")
 
         response = ex.exception.response.data.decode()
-        self.assertIn("You cannot get the required submission", response)
+        self.assertIn("No such submission", response)
 
     def test_get_user_invalid_token(self):
         Utils.start_contest()
@@ -121,7 +121,7 @@ class TestInfoHandler(unittest.TestCase):
             self.handler.get_user(token="invalid token", _ip="1.1.1.1")
 
         response = ex.exception.response.data.decode()
-        self.assertIn("Invalid login", response)
+        self.assertIn("No such user", response)
 
     def test_get_user(self):
         Utils.start_contest(since=100, duration=200)
@@ -166,7 +166,7 @@ class TestInfoHandler(unittest.TestCase):
             self.handler.get_submissions(token="invalid token", task="poldo", _ip="1.1.1.1")
 
         response = ex.exception.response.data.decode()
-        self.assertIn("Invalid login", response)
+        self.assertIn("No such user", response)
 
     def test_get_submissions_invalid_task(self):
         Utils.start_contest()
@@ -175,7 +175,7 @@ class TestInfoHandler(unittest.TestCase):
             self.handler.get_submissions(token="token", task="invalid task", _ip="1.1.1.1")
 
         response = ex.exception.response.data.decode()
-        self.assertIn("Invalid task", response)
+        self.assertIn("No such task", response)
 
     @patch("src.handlers.info_handler.InfoHandler.patch_output", return_value={"id":"outputid"})
     def test_patch_submission(self, mock):

--- a/test/handlers/test_upload_handler.py
+++ b/test/handlers/test_upload_handler.py
@@ -30,7 +30,7 @@ class TestInfoHandler(unittest.TestCase):
         self._insert_data()
 
         res = self.handler.upload_output(input_id="inputid", _ip="1.1.1.1",
-                                         _file_content="foobar".encode(), _file_name="output.txt")
+                                         file={"content":"foobar".encode(),"name":"output.txt"})
         self.assertEqual("outputid", res["id"])
         self.assertIn("output.txt", res["path"])
         self.assertEqual(42, res["validation"])
@@ -53,7 +53,7 @@ class TestInfoHandler(unittest.TestCase):
         self._insert_data()
 
         res = self.handler.upload_source(input_id="inputid", _ip="1.1.1.1",
-                                         _file_content="foobar".encode(), _file_name="source.txt")
+                                         file={"content":"foobar".encode(),"name":"source.txt"})
         self.assertEqual("sourceid", res["id"])
         self.assertIn("source.txt", res["path"])
         self.assertEqual("inputid", res["input"])

--- a/test/handlers/test_upload_handler.py
+++ b/test/handlers/test_upload_handler.py
@@ -26,9 +26,11 @@ class TestInfoHandler(unittest.TestCase):
     @patch("src.contest_manager.ContestManager.evaluate_output", return_value='{"validation":42}')
     @patch("src.database.Database.gen_id", return_value="outputid")
     def test_upload_output(self, gen_mock, eval_mock):
+        Utils.start_contest()
         self._insert_data()
 
-        res = self.handler.upload_output("inputid", "1.1.1.1", "foobar".encode(), "output.txt")
+        res = self.handler.upload_output(input_id="inputid", _ip="1.1.1.1",
+                                         _file_content="foobar".encode(), _file_name="output.txt")
         self.assertEqual("outputid", res["id"])
         self.assertIn("output.txt", res["path"])
         self.assertEqual(42, res["validation"])
@@ -39,16 +41,19 @@ class TestInfoHandler(unittest.TestCase):
             self.assertEqual("foobar", file.read())
 
     def test_upload_output_invalid_input(self):
+        Utils.start_contest()
         with self.assertRaises(Forbidden) as ex:
-            self.handler.upload_output("invalid input", "1.1.1.1", "foo", "bar")
+            self.handler.upload_output(input_id="invalid input", _ip="1.1.1.1", _file_content="foo", _file_name="bar")
 
         self.assertIn("No such input", ex.exception.response.data.decode())
 
     @patch("src.database.Database.gen_id", return_value="sourceid")
     def test_upload_source(self, gen_mock):
+        Utils.start_contest()
         self._insert_data()
 
-        res = self.handler.upload_source("inputid", "1.1.1.1", "foobar".encode(), "source.txt")
+        res = self.handler.upload_source(input_id="inputid", _ip="1.1.1.1",
+                                         _file_content="foobar".encode(), _file_name="source.txt")
         self.assertEqual("sourceid", res["id"])
         self.assertIn("source.txt", res["path"])
         self.assertEqual("inputid", res["input"])
@@ -58,8 +63,9 @@ class TestInfoHandler(unittest.TestCase):
             self.assertEqual("foobar", file.read())
 
     def test_upload_source_invalid_input(self):
+        Utils.start_contest()
         with self.assertRaises(Forbidden) as ex:
-            self.handler.upload_source("invalid input", "1.1.1.1", "foo", "bar")
+            self.handler.upload_source(input_id="invalid input", _ip="1.1.1.1", _file_content="foo", _file_name="bar")
 
         self.assertIn("No such input", ex.exception.response.data.decode())
 

--- a/test/test_validators.py
+++ b/test/test_validators.py
@@ -86,7 +86,7 @@ class TestValidators(unittest.TestCase):
         self.admin_only(admin_token=Config.admin_token, _ip="1.1.1.1")
 
     def test_validate_file(self):
-        self.file(_file_name="foo", _file_content="bar")
+        self.file(file={"content":"foobar".encode(),"name":"file.txt"})
 
     def test_valid_input_id_invalid_id(self):
         with self.assertRaises(Forbidden):

--- a/test/test_validators.py
+++ b/test/test_validators.py
@@ -25,11 +25,11 @@ class TestValidators(unittest.TestCase):
         self.log_backup = Logger.LOG_LEVEL
         Logger.LOG_LEVEL = 9001 # disable the logs
 
-    @Validators.validate_during_contest
+    @Validators.during_contest
     def only_during_contest(self, token=None):
         pass
 
-    @Validators.validate_admin_only
+    @Validators.admin_only
     def admin_only(self):
         pass
 

--- a/test/test_validators.py
+++ b/test/test_validators.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright 2017 - Edoardo Morassutto <edoardo.morassutto@gmail.com>
+
+import unittest
+
+from werkzeug.exceptions import Forbidden
+
+from src.config import Config
+from src.logger import Logger
+from src.validators import Validators
+from test.utils import Utils
+
+
+class TestValidators(unittest.TestCase):
+    def setUp(self):
+        Utils.prepare_test()
+        self.token_backup = Config.admin_token
+        Config.admin_token = 'admin token'
+
+        self.log_backup = Logger.LOG_LEVEL
+        Logger.LOG_LEVEL = 9001 # disable the logs
+
+    def test_validate_token(self):
+        Validators._validate_admin_token('admin token', '1.2.3.4')
+
+    def test_validate_invalid_token(self):
+        with self.assertRaises(Forbidden) as ex:
+            Validators._validate_admin_token('wrong token', '1.2.3.4')
+
+        self.assertIn("Invalid admin token", ex.exception.response.data.decode())
+
+        Logger.c.execute("SELECT * FROM logs WHERE category = 'LOGIN_ADMIN'")
+        row = Logger.c.fetchone()
+        self.assertIn("login failed", row[3])
+        self.assertIn("1.2.3.4", row[3])
+
+    def test_validate_token_log_ip(self):
+        Validators._validate_admin_token('admin token', '1.2.3.4')
+
+        Logger.c.execute("SELECT * FROM logs WHERE category = 'LOGIN_ADMIN'")
+        row = Logger.c.fetchone()
+        self.assertIn("new ip", row[3])
+        self.assertIn("1.2.3.4", row[3])
+
+    def test_validate_token_default(self):
+        Config.admin_token = Config.default_values["admin_token"]
+        Validators._validate_admin_token(Config.admin_token, '1.2.3.4')
+
+        Logger.c.execute("SELECT * FROM logs WHERE category = 'ADMIN'")
+        row = Logger.c.fetchone()
+        self.assertEqual("Using default admin token!", row[3])

--- a/test/test_validators.py
+++ b/test/test_validators.py
@@ -7,9 +7,10 @@
 
 import unittest
 
-from werkzeug.exceptions import Forbidden
+from werkzeug.exceptions import Forbidden, BadRequest
 
 from src.config import Config
+from src.database import Database
 from src.logger import Logger
 from src.validators import Validators
 from test.utils import Utils
@@ -23,6 +24,180 @@ class TestValidators(unittest.TestCase):
 
         self.log_backup = Logger.LOG_LEVEL
         Logger.LOG_LEVEL = 9001 # disable the logs
+
+    @Validators.during_contest
+    def only_during_contest(self, **kwargs):
+        return kwargs
+
+    @Validators.admin_only
+    def admin_only(self, **kwargs):
+        return kwargs
+
+    @Validators.valid_input_id
+    def valid_input_id(self, **kwargs):
+        return kwargs
+
+    @Validators.valid_output_id
+    def valid_output_id(self, **kwargs):
+        return kwargs
+
+    @Validators.valid_source_id
+    def valid_source_id(self, **kwargs):
+        return kwargs
+
+    @Validators.valid_submission_id
+    def valid_submission_id(self, **kwargs):
+        return kwargs
+
+    @Validators.valid_token
+    def valid_token(self, **kwargs):
+        return kwargs
+
+    @Validators.valid_task
+    def valid_task(self, **kwargs):
+        return kwargs
+
+    @Validators.register_ip
+    def register_ip(self, **kwargs):
+        return kwargs
+
+    def test_during_contest_not_started(self):
+        with self.assertRaises(Forbidden):
+            self.only_during_contest()
+
+    def test_during_contest_ended(self):
+        Utils.start_contest(since=100, duration=50)
+        with self.assertRaises(Forbidden):
+            self.only_during_contest()
+
+    def test_during_contest_extra_time(self):
+        Utils.start_contest(since=100, duration=50)
+        Database.add_user("token", "", "")
+        Database.set_extra_time("token", 100)
+        self.only_during_contest(token="token")
+
+    def test_admin_only_without_token(self):
+        with self.assertRaises(Forbidden):
+            self.admin_only()
+
+    def test_admin_only(self):
+        Utils.prepare_test()
+        Logger.set_log_level(9001)
+        self.admin_only(admin_token=Config.admin_token, _ip="1.1.1.1")
+
+    def test_valid_input_id_missing_parameter(self):
+        with self.assertRaises(BadRequest):
+            self.valid_input_id()
+
+    def test_valid_input_id_invalid_id(self):
+        with self.assertRaises(Forbidden):
+            self.valid_input_id(input_id="foobar")
+
+    def test_valid_input_id(self):
+        self._insert_data()
+        kwargs = self.valid_input_id(input_id="inputid")
+        self.assertIn("input", kwargs)
+
+    def test_valid_output_id_missing_parameter(self):
+        with self.assertRaises(BadRequest):
+            self.valid_output_id()
+
+    def test_valid_output_id_invalid_id(self):
+        with self.assertRaises(Forbidden):
+            self.valid_output_id(output_id="foobar")
+
+    def test_valid_output_id(self):
+        self._insert_data()
+        kwargs = self.valid_output_id(output_id="outputid")
+        self.assertIn("output", kwargs)
+
+    def test_valid_source_id_missing_parameter(self):
+        with self.assertRaises(BadRequest):
+            self.valid_source_id()
+
+    def test_valid_source_id_invalid_id(self):
+        with self.assertRaises(Forbidden):
+            self.valid_source_id(source_id="foobar")
+
+    def test_valid_source_id(self):
+        self._insert_data()
+        kwargs = self.valid_source_id(source_id="sourceid")
+        self.assertIn("source", kwargs)
+
+    def test_valid_submission_id_missing_parameter(self):
+        with self.assertRaises(BadRequest):
+            self.valid_submission_id()
+
+    def test_valid_submission_id_invalid_id(self):
+        with self.assertRaises(Forbidden):
+            self.valid_submission_id(submission_id="foobar")
+
+    def test_valid_submission_id(self):
+        self._insert_data()
+        Database.add_submission("submissionid", "inputid", "outputid", "sourceid", 42)
+        kwargs = self.valid_submission_id(submission_id="submissionid")
+        self.assertIn("submission", kwargs)
+
+    def test_valid_token_missing_parameter(self):
+        with self.assertRaises(BadRequest):
+            self.valid_token()
+
+    def test_valid_token_invalid_id(self):
+        with self.assertRaises(Forbidden):
+            self.valid_token(token="foobar")
+
+    def test_valid_token(self):
+        self._insert_data()
+        kwargs = self.valid_token(token="token")
+        self.assertIn("user", kwargs)
+
+    def test_valid_task_missing_parameter(self):
+        with self.assertRaises(BadRequest):
+            self.valid_task()
+
+    def test_valid_task_invalid_id(self):
+        with self.assertRaises(Forbidden):
+            self.valid_task(task="foobar")
+
+    def test_valid_task(self):
+        self._insert_data()
+        kwargs = self.valid_task(task="poldo")
+        self.assertIn("task", kwargs)
+
+    def test_register_ip_undetectable(self):
+        with self.assertRaises(BadRequest):
+            self.register_ip()
+
+    def test_register_ip_token(self):
+        self._insert_data()
+        self.register_ip(token="token", _ip="1.1.1.1")
+        users = Database.get_users()
+        self.assertEqual("1.1.1.1", users[0]["ip"][0]["ip"])
+
+    def test_register_ip_input(self):
+        self._insert_data()
+        self.register_ip(input_id="inputid", _ip="1.1.1.1")
+        users = Database.get_users()
+        self.assertEqual("1.1.1.1", users[0]["ip"][0]["ip"])
+
+    def test_register_ip_output(self):
+        self._insert_data()
+        self.register_ip(output_id="outputid", _ip="1.1.1.1")
+        users = Database.get_users()
+        self.assertEqual("1.1.1.1", users[0]["ip"][0]["ip"])
+
+    def test_register_ip_source(self):
+        self._insert_data()
+        self.register_ip(source_id="sourceid", _ip="1.1.1.1")
+        users = Database.get_users()
+        self.assertEqual("1.1.1.1", users[0]["ip"][0]["ip"])
+
+    def test_register_ip_submission(self):
+        self._insert_data()
+        Database.add_submission("submissionid", "inputid", "outputid", "sourceid", 42)
+        self.register_ip(submission_id="submissionid", _ip="1.1.1.1")
+        users = Database.get_users()
+        self.assertEqual("1.1.1.1", users[0]["ip"][0]["ip"])
 
     def test_validate_token(self):
         Validators._validate_admin_token('admin token', '1.2.3.4')
@@ -53,3 +228,10 @@ class TestValidators(unittest.TestCase):
         Logger.c.execute("SELECT * FROM logs WHERE category = 'ADMIN'")
         row = Logger.c.fetchone()
         self.assertEqual("Using default admin token!", row[3])
+
+    def _insert_data(self):
+        Database.add_user("token", "", "")
+        Database.add_task("poldo", "Poldo", "/path", 42, 1)
+        Database.add_input("inputid", "token", "poldo", 1, "/path", 42)
+        Database.add_output("outputid", "inputid", "/path", 42, "{}")
+        Database.add_source("sourceid", "inputid", "/path", 42)

--- a/test/test_validators.py
+++ b/test/test_validators.py
@@ -25,41 +25,41 @@ class TestValidators(unittest.TestCase):
         self.log_backup = Logger.LOG_LEVEL
         Logger.LOG_LEVEL = 9001 # disable the logs
 
-    @Validators.during_contest
-    def only_during_contest(self, **kwargs):
-        return kwargs
+    @Validators.validate_during_contest
+    def only_during_contest(self, token=None):
+        pass
 
-    @Validators.admin_only
-    def admin_only(self, **kwargs):
-        return kwargs
+    @Validators.validate_admin_only
+    def admin_only(self):
+        pass
 
-    @Validators.valid_input_id
-    def valid_input_id(self, **kwargs):
-        return kwargs
+    @Validators.validate_input_id
+    def valid_input_id(self, input):
+        return input
 
-    @Validators.valid_output_id
-    def valid_output_id(self, **kwargs):
-        return kwargs
+    @Validators.validate_output_id
+    def valid_output_id(self, output):
+        return output
 
-    @Validators.valid_source_id
-    def valid_source_id(self, **kwargs):
-        return kwargs
+    @Validators.validate_source_id
+    def valid_source_id(self, source):
+        return source
 
-    @Validators.valid_submission_id
-    def valid_submission_id(self, **kwargs):
-        return kwargs
+    @Validators.validate_submission_id
+    def valid_submission_id(self, submission):
+        return submission
 
-    @Validators.valid_token
-    def valid_token(self, **kwargs):
-        return kwargs
+    @Validators.validate_token
+    def valid_token(self, user):
+        return user
 
-    @Validators.valid_task
-    def valid_task(self, **kwargs):
-        return kwargs
+    @Validators.validate_task
+    def valid_task(self, task):
+        return task
 
-    @Validators.register_ip
-    def register_ip(self, **kwargs):
-        return kwargs
+    @Validators.register_user_ip
+    def register_ip(self, token=None, input_id=None, output_id=None, source_id=None, submission_id=None):
+        pass
 
     def test_during_contest_not_started(self):
         with self.assertRaises(Forbidden):
@@ -76,18 +76,10 @@ class TestValidators(unittest.TestCase):
         Database.set_extra_time("token", 100)
         self.only_during_contest(token="token")
 
-    def test_admin_only_without_token(self):
-        with self.assertRaises(Forbidden):
-            self.admin_only()
-
     def test_admin_only(self):
         Utils.prepare_test()
         Logger.set_log_level(9001)
         self.admin_only(admin_token=Config.admin_token, _ip="1.1.1.1")
-
-    def test_valid_input_id_missing_parameter(self):
-        with self.assertRaises(BadRequest):
-            self.valid_input_id()
 
     def test_valid_input_id_invalid_id(self):
         with self.assertRaises(Forbidden):
@@ -95,12 +87,8 @@ class TestValidators(unittest.TestCase):
 
     def test_valid_input_id(self):
         self._insert_data()
-        kwargs = self.valid_input_id(input_id="inputid")
-        self.assertIn("input", kwargs)
-
-    def test_valid_output_id_missing_parameter(self):
-        with self.assertRaises(BadRequest):
-            self.valid_output_id()
+        input = self.valid_input_id(input_id="inputid")
+        self.assertEqual("inputid", input["id"])
 
     def test_valid_output_id_invalid_id(self):
         with self.assertRaises(Forbidden):
@@ -108,12 +96,8 @@ class TestValidators(unittest.TestCase):
 
     def test_valid_output_id(self):
         self._insert_data()
-        kwargs = self.valid_output_id(output_id="outputid")
-        self.assertIn("output", kwargs)
-
-    def test_valid_source_id_missing_parameter(self):
-        with self.assertRaises(BadRequest):
-            self.valid_source_id()
+        output = self.valid_output_id(output_id="outputid")
+        self.assertEqual("outputid", output["id"])
 
     def test_valid_source_id_invalid_id(self):
         with self.assertRaises(Forbidden):
@@ -121,12 +105,8 @@ class TestValidators(unittest.TestCase):
 
     def test_valid_source_id(self):
         self._insert_data()
-        kwargs = self.valid_source_id(source_id="sourceid")
-        self.assertIn("source", kwargs)
-
-    def test_valid_submission_id_missing_parameter(self):
-        with self.assertRaises(BadRequest):
-            self.valid_submission_id()
+        source = self.valid_source_id(source_id="sourceid")
+        self.assertEqual("sourceid", source["id"])
 
     def test_valid_submission_id_invalid_id(self):
         with self.assertRaises(Forbidden):
@@ -135,12 +115,8 @@ class TestValidators(unittest.TestCase):
     def test_valid_submission_id(self):
         self._insert_data()
         Database.add_submission("submissionid", "inputid", "outputid", "sourceid", 42)
-        kwargs = self.valid_submission_id(submission_id="submissionid")
-        self.assertIn("submission", kwargs)
-
-    def test_valid_token_missing_parameter(self):
-        with self.assertRaises(BadRequest):
-            self.valid_token()
+        submission = self.valid_submission_id(submission_id="submissionid")
+        self.assertEqual("submissionid", submission["id"])
 
     def test_valid_token_invalid_id(self):
         with self.assertRaises(Forbidden):
@@ -148,12 +124,8 @@ class TestValidators(unittest.TestCase):
 
     def test_valid_token(self):
         self._insert_data()
-        kwargs = self.valid_token(token="token")
-        self.assertIn("user", kwargs)
-
-    def test_valid_task_missing_parameter(self):
-        with self.assertRaises(BadRequest):
-            self.valid_task()
+        user = self.valid_token(token="token")
+        self.assertEqual("token", user["token"])
 
     def test_valid_task_invalid_id(self):
         with self.assertRaises(Forbidden):
@@ -161,12 +133,8 @@ class TestValidators(unittest.TestCase):
 
     def test_valid_task(self):
         self._insert_data()
-        kwargs = self.valid_task(task="poldo")
-        self.assertIn("task", kwargs)
-
-    def test_register_ip_undetectable(self):
-        with self.assertRaises(BadRequest):
-            self.register_ip()
+        task = self.valid_task(task="poldo")
+        self.assertEqual("poldo", task["name"])
 
     def test_register_ip_token(self):
         self._insert_data()

--- a/test/test_validators.py
+++ b/test/test_validators.py
@@ -33,6 +33,10 @@ class TestValidators(unittest.TestCase):
     def admin_only(self):
         pass
 
+    @Validators.validate_file
+    def file(self, file):
+        return file
+
     @Validators.validate_input_id
     def valid_input_id(self, input):
         return input
@@ -80,6 +84,9 @@ class TestValidators(unittest.TestCase):
         Utils.prepare_test()
         Logger.set_log_level(9001)
         self.admin_only(admin_token=Config.admin_token, _ip="1.1.1.1")
+
+    def test_validate_file(self):
+        self.file(_file_name="foo", _file_content="bar")
 
     def test_valid_input_id_invalid_id(self):
         with self.assertRaises(Forbidden):

--- a/test/utils.py
+++ b/test/utils.py
@@ -88,3 +88,7 @@ class Utils:
     def random_string(length=8, chars=string.ascii_uppercase+string.ascii_lowercase+string.digits):
         return ''.join(random.choice(chars) for _ in range(length))
 
+    @staticmethod
+    def start_contest(since=5, duration=18000):
+        Database.set_meta("start_time", int(datetime.datetime.now().timestamp() - since))
+        Database.set_meta("contest_duration", duration)


### PR DESCRIPTION
To reduce code duplication I've implemented a simple to use validation process for the requests.

Before calling an handler a series of validation methods is called. These methods will check many things, for example if the contest is running, if the provided id is valid, and many other things including logging the user ip.

To enable this process you only need to add a decorator to the endpoint, like
```python
@Validators.validate_during_contest
@Validators.register_user_ip
@Validators.validate_token
@Validators.validate_task
def generate_input(self, task, user):
    # task and user are the rows from the db corresponding to the request parameters
    # task and token
```

A list of the implemented decorators can be found in the `src/validators.py` file.